### PR TITLE
Remove 'Follow' as it is an unused feature

### DIFF
--- a/ckanext/dia_theme/templates/group/snippets/info.html
+++ b/ckanext/dia_theme/templates/group/snippets/info.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+    {% block nums %}
+      <div class="nums">
+        <dl>
+          <dt>{{ _('Datasets') }}</dt>
+          <dd>{{ h.SI_number_span(group.package_count) }}</dd>
+        </dl>
+      </div>
+    {% endblock %}
+    
+    {% block follow %}
+    {% endblock %}

--- a/ckanext/dia_theme/templates/package/snippets/info.html
+++ b/ckanext/dia_theme/templates/package/snippets/info.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+    {% block nums %}
+    {% endblock %}
+    
+    {% block follow_button %}
+    {% endblock %}

--- a/ckanext/dia_theme/templates/snippets/organization.html
+++ b/ckanext/dia_theme/templates/snippets/organization.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+{% block nums %}
+        <div class="nums">
+          <dl>
+            <dt>{{ _('Datasets') }}</dt>
+            <dd>{{ h.SI_number_span(organization.package_count) }}</dd>
+          </dl>
+        </div>
+{% endblock %}
+        
+{% block follow %}
+{% endblock %}


### PR DESCRIPTION
Since data.govt.nz doesn't make use of accounts the "follow" feature is somewhat redundant for now.

This PR removes the use and display of followers of:
 - Datasets
 - Organisations
 - Groups

Can we reenabled later should we offer wider user accounts.