### PR TITLE
One header element with two aria navigation menus

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -197,7 +197,7 @@ body {
   font-size: 14px;
   line-height: 20px;
   color: #333333;
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
 }
 a {
   color: #004a61;
@@ -555,7 +555,7 @@ cite {
   font-style: normal;
 }
 .muted {
-  color: #999;
+  color: #999999;
 }
 a.muted:hover,
 a.muted:focus {
@@ -619,7 +619,7 @@ h5 small,
 h6 small {
   font-weight: normal;
   line-height: 1;
-  color: #999;
+  color: #999999;
 }
 h1,
 h2,
@@ -659,7 +659,7 @@ h4 small {
 .page-header {
   padding-bottom: 9px;
   margin: 20px 0 30px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid #eeeeee;
 }
 ul,
 ol {
@@ -734,13 +734,13 @@ dd {
 hr {
   margin: 20px 0;
   border: 0;
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #fff;
+  border-top: 1px solid #eeeeee;
+  border-bottom: 1px solid #ffffff;
 }
 abbr[title],
 abbr[data-original-title] {
   cursor: help;
-  border-bottom: 1px dotted #999;
+  border-bottom: 1px dotted #999999;
 }
 abbr.initialism {
   font-size: 90%;
@@ -749,7 +749,7 @@ abbr.initialism {
 blockquote {
   padding: 0 0 0 15px;
   margin: 0 0 20px;
-  border-left: 5px solid #eee;
+  border-left: 5px solid #eeeeee;
 }
 blockquote p {
   margin-bottom: 0;
@@ -760,7 +760,7 @@ blockquote p {
 blockquote small {
   display: block;
   line-height: 20px;
-  color: #999;
+  color: #999999;
 }
 blockquote small:before {
   content: '\2014 \00A0';
@@ -769,7 +769,7 @@ blockquote.pull-right {
   float: right;
   padding-right: 15px;
   padding-left: 0;
-  border-right: 5px solid #eee;
+  border-right: 5px solid #eeeeee;
   border-left: 0;
 }
 blockquote.pull-right p,
@@ -799,7 +799,7 @@ pre {
   padding: 0 3px 2px;
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
   font-size: 12px;
-  color: #333;
+  color: #333333;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -858,13 +858,13 @@ legend {
   margin-bottom: 20px;
   font-size: 21px;
   line-height: 40px;
-  color: #333;
+  color: #333333;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }
 legend small {
   font-size: 15px;
-  color: #999;
+  color: #999999;
 }
 label,
 input,
@@ -908,7 +908,7 @@ input[type="color"],
   margin-bottom: 10px;
   font-size: 14px;
   line-height: 20px;
-  color: #555;
+  color: #555555;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -938,8 +938,8 @@ input[type="search"],
 input[type="tel"],
 input[type="color"],
 .uneditable-input {
-  background-color: #fff;
-  border: 1px solid #ccc;
+  background-color: #ffffff;
+  border: 1px solid #cccccc;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -1000,8 +1000,8 @@ input[type="file"] {
 }
 select {
   width: 220px;
-  border: 1px solid #ccc;
-  background-color: #fff;
+  border: 1px solid #cccccc;
+  background-color: #ffffff;
 }
 select[multiple],
 select[size] {
@@ -1017,9 +1017,9 @@ input[type="checkbox"]:focus {
 }
 .uneditable-input,
 .uneditable-textarea {
-  color: #999;
+  color: #999999;
   background-color: #fcfcfc;
-  border-color: #ccc;
+  border-color: #cccccc;
   -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
   -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
@@ -1035,15 +1035,15 @@ input[type="checkbox"]:focus {
 }
 input:-moz-placeholder,
 textarea:-moz-placeholder {
-  color: #999;
+  color: #999999;
 }
 input:-ms-input-placeholder,
 textarea:-ms-input-placeholder {
-  color: #999;
+  color: #999999;
 }
 input::-webkit-input-placeholder,
 textarea::-webkit-input-placeholder {
-  color: #999;
+  color: #999999;
 }
 .radio,
 .checkbox {
@@ -1206,7 +1206,7 @@ input[readonly],
 select[readonly],
 textarea[readonly] {
   cursor: not-allowed;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 input[type="radio"][disabled],
 input[type="checkbox"][disabled],
@@ -1450,8 +1450,8 @@ select:focus:invalid:focus {
   font-weight: normal;
   line-height: 20px;
   text-align: center;
-  text-shadow: 0 1px 0 #fff;
-  background-color: #eee;
+  text-shadow: 0 1px 0 #ffffff;
+  background-color: #eeeeee;
   border: 1px solid #ccc;
 }
 .input-append .add-on,
@@ -1701,7 +1701,7 @@ table {
   line-height: 20px;
   text-align: left;
   vertical-align: top;
-  border-top: 1px solid #ddd;
+  border-top: 1px solid #dddddd;
 }
 .table th {
   font-weight: bold;
@@ -1718,17 +1718,17 @@ table {
   border-top: 0;
 }
 .table tbody + tbody {
-  border-top: 2px solid #ddd;
+  border-top: 2px solid #dddddd;
 }
 .table .table {
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
 }
 .table-condensed th,
 .table-condensed td {
   padding: 4px 5px;
 }
 .table-bordered {
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   border-collapse: separate;
   *border-collapse: collapse;
   border-left: 0;
@@ -1738,7 +1738,7 @@ table {
 }
 .table-bordered th,
 .table-bordered td {
-  border-left: 1px solid #ddd;
+  border-left: 1px solid #dddddd;
 }
 .table-bordered caption + thead tr:first-child th,
 .table-bordered caption + tbody tr:first-child th,
@@ -1937,7 +1937,7 @@ table th[class*="span"],
   width: 0;
   height: 0;
   vertical-align: top;
-  border-top: 4px solid #000;
+  border-top: 4px solid #000000;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
   content: "";
@@ -1957,7 +1957,7 @@ table th[class*="span"],
   padding: 5px 0;
   margin: 2px 0 0;
   list-style: none;
-  background-color: #fff;
+  background-color: #ffffff;
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.2);
   *border-right-width: 2px;
@@ -1983,7 +1983,7 @@ table th[class*="span"],
   *margin: -5px 0 5px;
   overflow: hidden;
   background-color: #e5e5e5;
-  border-bottom: 1px solid #fff;
+  border-bottom: 1px solid #ffffff;
 }
 .dropdown-menu > li > a {
   display: block;
@@ -1991,7 +1991,7 @@ table th[class*="span"],
   clear: both;
   font-weight: normal;
   line-height: 20px;
-  color: #333;
+  color: #333333;
   white-space: nowrap;
 }
 .dropdown-menu > li > a:hover,
@@ -1999,7 +1999,7 @@ table th[class*="span"],
 .dropdown-submenu:hover > a,
 .dropdown-submenu:focus > a {
   text-decoration: none;
-  color: #fff;
+  color: #ffffff;
   background-color: #004257;
   background-image: -moz-linear-gradient(top, #004a61, #003748);
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#004a61), to(#003748));
@@ -2012,7 +2012,7 @@ table th[class*="span"],
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
 .dropdown-menu > .active > a:focus {
-  color: #fff;
+  color: #ffffff;
   text-decoration: none;
   outline: 0;
   background-color: #004257;
@@ -2027,7 +2027,7 @@ table th[class*="span"],
 .dropdown-menu > .disabled > a,
 .dropdown-menu > .disabled > a:hover,
 .dropdown-menu > .disabled > a:focus {
-  color: #999;
+  color: #999999;
 }
 .dropdown-menu > .disabled > a:hover,
 .dropdown-menu > .disabled > a:focus {
@@ -2058,7 +2058,7 @@ table th[class*="span"],
 .dropup .caret,
 .navbar-fixed-bottom .dropdown .caret {
   border-top: 0;
-  border-bottom: 4px solid #000;
+  border-bottom: 4px solid #000000;
   content: "";
 }
 .dropup .dropdown-menu,
@@ -2105,7 +2105,7 @@ table th[class*="span"],
   margin-right: -10px;
 }
 .dropdown-submenu:hover > a:after {
-  border-left-color: #fff;
+  border-left-color: #ffffff;
 }
 .dropdown-submenu.pull-left {
   float: none;
@@ -2184,14 +2184,14 @@ table th[class*="span"],
   font-size: 20px;
   font-weight: bold;
   line-height: 20px;
-  color: #000;
+  color: #000000;
   text-shadow: 0 1px 0 #ffffff;
   opacity: 0.2;
   filter: alpha(opacity=20);
 }
 .close:hover,
 .close:focus {
-  color: #000;
+  color: #000000;
   text-decoration: none;
   cursor: pointer;
   opacity: 0.4;
@@ -2216,7 +2216,7 @@ button.close {
   text-align: center;
   vertical-align: middle;
   cursor: pointer;
-  color: #333;
+  color: #333333;
   text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
   background-color: #f7f7f7;
   background-image: -moz-linear-gradient(top, #ffffff, #eaeaea);
@@ -2231,7 +2231,7 @@ button.close {
   *background-color: #eaeaea;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   *border: 0;
   border-bottom-color: #b3b3b3;
   -webkit-border-radius: 4px;
@@ -2248,7 +2248,7 @@ button.close {
 .btn.active,
 .btn.disabled,
 .btn[disabled] {
-  color: #333;
+  color: #333333;
   background-color: #eaeaea;
   *background-color: #dddddd;
 }
@@ -2261,7 +2261,7 @@ button.close {
 }
 .btn:hover,
 .btn:focus {
-  color: #333;
+  color: #333333;
   text-decoration: none;
   background-position: 0 -15px;
   -webkit-transition: background-position 0.1s linear;
@@ -2351,7 +2351,7 @@ input[type="button"].btn-block {
   color: rgba(255, 255, 255, 0.75);
 }
 .btn-primary {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #206b82;
   background-image: -moz-linear-gradient(top, #30778d, #085871);
@@ -2373,7 +2373,7 @@ input[type="button"].btn-block {
 .btn-primary.active,
 .btn-primary.disabled,
 .btn-primary[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #085871;
   *background-color: #064559;
 }
@@ -2382,7 +2382,7 @@ input[type="button"].btn-block {
   background-color: #053341 \9;
 }
 .btn-warning {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #faa732;
   background-image: -moz-linear-gradient(top, #fbb450, #f89406);
@@ -2404,7 +2404,7 @@ input[type="button"].btn-block {
 .btn-warning.active,
 .btn-warning.disabled,
 .btn-warning[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #f89406;
   *background-color: #df8505;
 }
@@ -2413,7 +2413,7 @@ input[type="button"].btn-block {
   background-color: #c67605 \9;
 }
 .btn-danger {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #da4f49;
   background-image: -moz-linear-gradient(top, #ee5f5b, #bd362f);
@@ -2435,7 +2435,7 @@ input[type="button"].btn-block {
 .btn-danger.active,
 .btn-danger.disabled,
 .btn-danger[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #bd362f;
   *background-color: #a9302a;
 }
@@ -2444,7 +2444,7 @@ input[type="button"].btn-block {
   background-color: #942a25 \9;
 }
 .btn-success {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #5bb75b;
   background-image: -moz-linear-gradient(top, #62c462, #51a351);
@@ -2466,7 +2466,7 @@ input[type="button"].btn-block {
 .btn-success.active,
 .btn-success.disabled,
 .btn-success[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #51a351;
   *background-color: #499249;
 }
@@ -2475,7 +2475,7 @@ input[type="button"].btn-block {
   background-color: #408140 \9;
 }
 .btn-info {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #49afcd;
   background-image: -moz-linear-gradient(top, #5bc0de, #2f96b4);
@@ -2497,7 +2497,7 @@ input[type="button"].btn-block {
 .btn-info.active,
 .btn-info.disabled,
 .btn-info[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #2f96b4;
   *background-color: #2a85a0;
 }
@@ -2506,19 +2506,19 @@ input[type="button"].btn-block {
   background-color: #24748c \9;
 }
 .btn-inverse {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #363636;
-  background-image: -moz-linear-gradient(top, #444, #222);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#444), to(#222));
-  background-image: -webkit-linear-gradient(top, #444, #222);
-  background-image: -o-linear-gradient(top, #444, #222);
-  background-image: linear-gradient(to bottom, #444, #222);
+  background-image: -moz-linear-gradient(top, #444444, #222222);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#444444), to(#222222));
+  background-image: -webkit-linear-gradient(top, #444444, #222222);
+  background-image: -o-linear-gradient(top, #444444, #222222);
+  background-image: linear-gradient(to bottom, #444444, #222222);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff444444', endColorstr='#ff222222', GradientType=0);
-  border-color: #222 #222 #000000;
+  border-color: #222222 #222222 #000000;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #222;
+  *background-color: #222222;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
@@ -2528,8 +2528,8 @@ input[type="button"].btn-block {
 .btn-inverse.active,
 .btn-inverse.disabled,
 .btn-inverse[disabled] {
-  color: #fff;
-  background-color: #222;
+  color: #ffffff;
+  background-color: #222222;
   *background-color: #151515;
 }
 .btn-inverse:active,
@@ -2586,7 +2586,7 @@ input[type="submit"].btn.btn-mini {
 }
 .btn-link[disabled]:hover,
 .btn-link[disabled]:focus {
-  color: #333;
+  color: #333333;
   text-decoration: none;
 }
 .btn-group {
@@ -2735,7 +2735,7 @@ input[type="submit"].btn.btn-mini {
   background-color: #2f96b4;
 }
 .btn-group.open .btn-inverse.dropdown-toggle {
-  background-color: #222;
+  background-color: #222222;
 }
 .btn .caret {
   margin-top: 8px;
@@ -2762,8 +2762,8 @@ input[type="submit"].btn.btn-mini {
 .btn-info .caret,
 .btn-success .caret,
 .btn-inverse .caret {
-  border-top-color: #fff;
-  border-bottom-color: #fff;
+  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
 }
 .btn-group-vertical {
   display: inline-block;
@@ -2874,7 +2874,7 @@ input[type="submit"].btn.btn-mini {
 .nav > li > a:hover,
 .nav > li > a:focus {
   text-decoration: none;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 .nav > li > a > img {
   max-width: none;
@@ -2888,7 +2888,7 @@ input[type="submit"].btn.btn-mini {
   font-size: 11px;
   font-weight: bold;
   line-height: 20px;
-  color: #999;
+  color: #999999;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
   text-transform: uppercase;
 }
@@ -2912,7 +2912,7 @@ input[type="submit"].btn.btn-mini {
 .nav-list > .active > a,
 .nav-list > .active > a:hover,
 .nav-list > .active > a:focus {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.2);
   background-color: #004a61;
 }
@@ -2927,7 +2927,7 @@ input[type="submit"].btn.btn-mini {
   *margin: -5px 0 5px;
   overflow: hidden;
   background-color: #e5e5e5;
-  border-bottom: 1px solid #fff;
+  border-bottom: 1px solid #ffffff;
 }
 .nav-tabs,
 .nav-pills {
@@ -2973,13 +2973,13 @@ input[type="submit"].btn.btn-mini {
 }
 .nav-tabs > li > a:hover,
 .nav-tabs > li > a:focus {
-  border-color: #eee #eee #ddd;
+  border-color: #eeeeee #eeeeee #dddddd;
 }
 .nav-tabs > .active > a,
 .nav-tabs > .active > a:hover,
 .nav-tabs > .active > a:focus {
-  color: #555;
-  background-color: #EEEEEE;
+  color: #555555;
+  background-color: #eeeeee;
   border: 1px solid #ddd;
   border-bottom-color: transparent;
   cursor: default;
@@ -2996,7 +2996,7 @@ input[type="submit"].btn.btn-mini {
 .nav-pills > .active > a,
 .nav-pills > .active > a:hover,
 .nav-pills > .active > a:focus {
-  color: #fff;
+  color: #ffffff;
   background-color: #004a61;
 }
 .nav-stacked > li {
@@ -3070,8 +3070,8 @@ input[type="submit"].btn.btn-mini {
   border-bottom-color: #fff;
 }
 .nav-tabs .active .dropdown-toggle .caret {
-  border-top-color: #555;
-  border-bottom-color: #555;
+  border-top-color: #555555;
+  border-bottom-color: #555555;
 }
 .nav > .dropdown.active > a:hover,
 .nav > .dropdown.active > a:focus {
@@ -3081,22 +3081,22 @@ input[type="submit"].btn.btn-mini {
 .nav-pills .open .dropdown-toggle,
 .nav > li.dropdown.open.active > a:hover,
 .nav > li.dropdown.open.active > a:focus {
-  color: #fff;
-  background-color: #999;
-  border-color: #999;
+  color: #ffffff;
+  background-color: #999999;
+  border-color: #999999;
 }
 .nav li.dropdown.open .caret,
 .nav li.dropdown.open.active .caret,
 .nav li.dropdown.open a:hover .caret,
 .nav li.dropdown.open a:focus .caret {
-  border-top-color: #fff;
-  border-bottom-color: #fff;
+  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
   opacity: 1;
   filter: alpha(opacity=100);
 }
 .tabs-stacked .open > a:hover,
 .tabs-stacked .open > a:focus {
-  border-color: #999;
+  border-color: #999999;
 }
 .tabbable {
   *zoom: 1;
@@ -3171,13 +3171,13 @@ input[type="submit"].btn.btn-mini {
 }
 .tabs-left > .nav-tabs > li > a:hover,
 .tabs-left > .nav-tabs > li > a:focus {
-  border-color: #eee #ddd #eee #eee;
+  border-color: #eeeeee #dddddd #eeeeee #eeeeee;
 }
 .tabs-left > .nav-tabs .active > a,
 .tabs-left > .nav-tabs .active > a:hover,
 .tabs-left > .nav-tabs .active > a:focus {
   border-color: #ddd transparent #ddd #ddd;
-  *border-right-color: #fff;
+  *border-right-color: #ffffff;
 }
 .tabs-right > .nav-tabs {
   float: right;
@@ -3192,16 +3192,16 @@ input[type="submit"].btn.btn-mini {
 }
 .tabs-right > .nav-tabs > li > a:hover,
 .tabs-right > .nav-tabs > li > a:focus {
-  border-color: #eee #eee #eee #ddd;
+  border-color: #eeeeee #eeeeee #eeeeee #dddddd;
 }
 .tabs-right > .nav-tabs .active > a,
 .tabs-right > .nav-tabs .active > a:hover,
 .tabs-right > .nav-tabs .active > a:focus {
   border-color: #ddd #ddd #ddd transparent;
-  *border-left-color: #fff;
+  *border-left-color: #ffffff;
 }
 .nav > .disabled > a {
-  color: #999;
+  color: #999999;
 }
 .nav > .disabled > a:hover,
 .nav > .disabled > a:focus {
@@ -3259,7 +3259,7 @@ input[type="submit"].btn.btn-mini {
   margin-left: -20px;
   font-size: 20px;
   font-weight: 200;
-  color: #777;
+  color: #777777;
   text-shadow: 0 1px 0 #ffffff;
 }
 .navbar .brand:hover,
@@ -3269,14 +3269,14 @@ input[type="submit"].btn.btn-mini {
 .navbar-text {
   margin-bottom: 0;
   line-height: 40px;
-  color: #777;
+  color: #777777;
 }
 .navbar-link {
-  color: #777;
+  color: #777777;
 }
 .navbar-link:hover,
 .navbar-link:focus {
-  color: #333;
+  color: #333333;
 }
 .navbar .divider-vertical {
   height: 40px;
@@ -3422,7 +3422,7 @@ input[type="submit"].btn.btn-mini {
 .navbar .nav > li > a {
   float: none;
   padding: 10px 15px 10px;
-  color: #777;
+  color: #777777;
   text-decoration: none;
   text-shadow: 0 1px 0 #ffffff;
 }
@@ -3432,13 +3432,13 @@ input[type="submit"].btn.btn-mini {
 .navbar .nav > li > a:focus,
 .navbar .nav > li > a:hover {
   background-color: transparent;
-  color: #333;
+  color: #333333;
   text-decoration: none;
 }
 .navbar .nav > .active > a,
 .navbar .nav > .active > a:hover,
 .navbar .nav > .active > a:focus {
-  color: #555;
+  color: #555555;
   text-decoration: none;
   background-color: #e5e5e5;
   -webkit-box-shadow: inset 0 3px 8px rgba(0, 0, 0, 0.125);
@@ -3451,7 +3451,7 @@ input[type="submit"].btn.btn-mini {
   padding: 7px 10px;
   margin-left: 5px;
   margin-right: 5px;
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #ededed;
   background-image: -moz-linear-gradient(top, #f2f2f2, #e5e5e5);
@@ -3476,7 +3476,7 @@ input[type="submit"].btn.btn-mini {
 .navbar .btn-navbar.active,
 .navbar .btn-navbar.disabled,
 .navbar .btn-navbar[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #e5e5e5;
   *background-color: #d9d9d9;
 }
@@ -3515,7 +3515,7 @@ input[type="submit"].btn.btn-mini {
   display: inline-block;
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
-  border-bottom: 6px solid #fff;
+  border-bottom: 6px solid #ffffff;
   position: absolute;
   top: -6px;
   left: 10px;
@@ -3528,31 +3528,31 @@ input[type="submit"].btn.btn-mini {
   top: auto;
 }
 .navbar-fixed-bottom .nav > li > .dropdown-menu:after {
-  border-top: 6px solid #fff;
+  border-top: 6px solid #ffffff;
   border-bottom: 0;
   bottom: -6px;
   top: auto;
 }
 .navbar .nav li.dropdown > a:hover .caret,
 .navbar .nav li.dropdown > a:focus .caret {
-  border-top-color: #333;
-  border-bottom-color: #333;
+  border-top-color: #333333;
+  border-bottom-color: #333333;
 }
 .navbar .nav li.dropdown.open > .dropdown-toggle,
 .navbar .nav li.dropdown.active > .dropdown-toggle,
 .navbar .nav li.dropdown.open.active > .dropdown-toggle {
   background-color: #e5e5e5;
-  color: #555;
+  color: #555555;
 }
 .navbar .nav li.dropdown > .dropdown-toggle .caret {
-  border-top-color: #777;
-  border-bottom-color: #777;
+  border-top-color: #777777;
+  border-bottom-color: #777777;
 }
 .navbar .nav li.dropdown.open > .dropdown-toggle .caret,
 .navbar .nav li.dropdown.active > .dropdown-toggle .caret,
 .navbar .nav li.dropdown.open.active > .dropdown-toggle .caret {
-  border-top-color: #555;
-  border-bottom-color: #555;
+  border-top-color: #555555;
+  border-bottom-color: #555555;
 }
 .navbar .pull-right > li > .dropdown-menu,
 .navbar .nav > li > .dropdown-menu.pull-right {
@@ -3592,38 +3592,38 @@ input[type="submit"].btn.btn-mini {
 }
 .navbar-inverse .brand,
 .navbar-inverse .nav > li > a {
-  color: #999;
+  color: #999999;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
 .navbar-inverse .brand:hover,
 .navbar-inverse .nav > li > a:hover,
 .navbar-inverse .brand:focus,
 .navbar-inverse .nav > li > a:focus {
-  color: #fff;
+  color: #ffffff;
 }
 .navbar-inverse .brand {
-  color: #999;
+  color: #999999;
 }
 .navbar-inverse .navbar-text {
-  color: #999;
+  color: #999999;
 }
 .navbar-inverse .nav > li > a:focus,
 .navbar-inverse .nav > li > a:hover {
   background-color: transparent;
-  color: #fff;
+  color: #ffffff;
 }
 .navbar-inverse .nav .active > a,
 .navbar-inverse .nav .active > a:hover,
 .navbar-inverse .nav .active > a:focus {
-  color: #fff;
+  color: #ffffff;
   background-color: #111111;
 }
 .navbar-inverse .navbar-link {
-  color: #999;
+  color: #999999;
 }
 .navbar-inverse .navbar-link:hover,
 .navbar-inverse .navbar-link:focus {
-  color: #fff;
+  color: #ffffff;
 }
 .navbar-inverse .divider-vertical {
   border-left-color: #111111;
@@ -3633,25 +3633,25 @@ input[type="submit"].btn.btn-mini {
 .navbar-inverse .nav li.dropdown.active > .dropdown-toggle,
 .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle {
   background-color: #111111;
-  color: #fff;
+  color: #ffffff;
 }
 .navbar-inverse .nav li.dropdown > a:hover .caret,
 .navbar-inverse .nav li.dropdown > a:focus .caret {
-  border-top-color: #fff;
-  border-bottom-color: #fff;
+  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
 }
 .navbar-inverse .nav li.dropdown > .dropdown-toggle .caret {
-  border-top-color: #999;
-  border-bottom-color: #999;
+  border-top-color: #999999;
+  border-bottom-color: #999999;
 }
 .navbar-inverse .nav li.dropdown.open > .dropdown-toggle .caret,
 .navbar-inverse .nav li.dropdown.active > .dropdown-toggle .caret,
 .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle .caret {
-  border-top-color: #fff;
-  border-bottom-color: #fff;
+  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
 }
 .navbar-inverse .navbar-search .search-query {
-  color: #fff;
+  color: #ffffff;
   background-color: #515151;
   border-color: #111111;
   -webkit-box-shadow: inset 0 1px 2px rgba(0,0,0,.1), 0 1px 0 rgba(255,255,255,.15);
@@ -3663,20 +3663,20 @@ input[type="submit"].btn.btn-mini {
   transition: none;
 }
 .navbar-inverse .navbar-search .search-query:-moz-placeholder {
-  color: #ccc;
+  color: #cccccc;
 }
 .navbar-inverse .navbar-search .search-query:-ms-input-placeholder {
-  color: #ccc;
+  color: #cccccc;
 }
 .navbar-inverse .navbar-search .search-query::-webkit-input-placeholder {
-  color: #ccc;
+  color: #cccccc;
 }
 .navbar-inverse .navbar-search .search-query:focus,
 .navbar-inverse .navbar-search .search-query.focused {
   padding: 5px 15px;
-  color: #333;
-  text-shadow: 0 1px 0 #fff;
-  background-color: #fff;
+  color: #333333;
+  text-shadow: 0 1px 0 #ffffff;
+  background-color: #ffffff;
   border: 0;
   -webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
   -moz-box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
@@ -3684,7 +3684,7 @@ input[type="submit"].btn.btn-mini {
   outline: 0;
 }
 .navbar-inverse .btn-navbar {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #0e0e0e;
   background-image: -moz-linear-gradient(top, #151515, #040404);
@@ -3706,7 +3706,7 @@ input[type="submit"].btn.btn-mini {
 .navbar-inverse .btn-navbar.active,
 .navbar-inverse .btn-navbar.disabled,
 .navbar-inverse .btn-navbar[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #040404;
   *background-color: #000000;
 }
@@ -3728,14 +3728,14 @@ input[type="submit"].btn.btn-mini {
   *display: inline;
   /* IE7 inline-block hack */
   *zoom: 1;
-  text-shadow: 0 1px 0 #fff;
+  text-shadow: 0 1px 0 #ffffff;
 }
 .breadcrumb > li > .divider {
   padding: 0 5px;
   color: #ccc;
 }
 .breadcrumb > .active {
-  color: #999;
+  color: #999999;
 }
 .pagination {
   margin: 20px 0;
@@ -3763,8 +3763,8 @@ input[type="submit"].btn.btn-mini {
   padding: 4px 12px;
   line-height: 20px;
   text-decoration: none;
-  background-color: #fff;
-  border: 1px solid #ddd;
+  background-color: #ffffff;
+  border: 1px solid #dddddd;
   border-left-width: 0;
 }
 .pagination ul > li > a:hover,
@@ -3775,14 +3775,14 @@ input[type="submit"].btn.btn-mini {
 }
 .pagination ul > .active > a,
 .pagination ul > .active > span {
-  color: #999;
+  color: #999999;
   cursor: default;
 }
 .pagination ul > .disabled > span,
 .pagination ul > .disabled > a,
 .pagination ul > .disabled > a:hover,
 .pagination ul > .disabled > a:focus {
-  color: #999;
+  color: #999999;
   background-color: transparent;
   cursor: default;
 }
@@ -3911,7 +3911,7 @@ input[type="submit"].btn.btn-mini {
 .pager .disabled > a:hover,
 .pager .disabled > a:focus,
 .pager .disabled > span {
-  color: #999;
+  color: #999999;
   background-color: #fff;
   cursor: default;
 }
@@ -3922,7 +3922,7 @@ input[type="submit"].btn.btn-mini {
   bottom: 0;
   left: 0;
   z-index: 1040;
-  background-color: #000;
+  background-color: #000000;
 }
 .modal-backdrop.fade {
   opacity: 0;
@@ -3939,7 +3939,7 @@ input[type="submit"].btn.btn-mini {
   z-index: 1050;
   width: 560px;
   margin-left: -280px;
-  background-color: #fff;
+  background-color: #ffffff;
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.3);
   *border: 1px solid #999;
@@ -3956,10 +3956,10 @@ input[type="submit"].btn.btn-mini {
   outline: none;
 }
 .modal.fade {
-  -webkit-transition: opacity 0.3s linear, top 0.3s ease-out;
-  -moz-transition: opacity 0.3s linear, top 0.3s ease-out;
-  -o-transition: opacity 0.3s linear, top 0.3s ease-out;
-  transition: opacity 0.3s linear, top 0.3s ease-out;
+  -webkit-transition: opacity .3s linear, top .3s ease-out;
+  -moz-transition: opacity .3s linear, top .3s ease-out;
+  -o-transition: opacity .3s linear, top .3s ease-out;
+  transition: opacity .3s linear, top .3s ease-out;
   top: -25%;
 }
 .modal.fade.in {
@@ -3994,9 +3994,9 @@ input[type="submit"].btn.btn-mini {
   -webkit-border-radius: 0 0 6px 6px;
   -moz-border-radius: 0 0 6px 6px;
   border-radius: 0 0 6px 6px;
-  -webkit-box-shadow: inset 0 1px 0 #fff;
-  -moz-box-shadow: inset 0 1px 0 #fff;
-  box-shadow: inset 0 1px 0 #fff;
+  -webkit-box-shadow: inset 0 1px 0 #ffffff;
+  -moz-box-shadow: inset 0 1px 0 #ffffff;
+  box-shadow: inset 0 1px 0 #ffffff;
   *zoom: 1;
 }
 .modal-footer:before,
@@ -4051,10 +4051,10 @@ input[type="submit"].btn.btn-mini {
 .tooltip-inner {
   max-width: 200px;
   padding: 8px;
-  color: #fff;
+  color: #ffffff;
   text-align: center;
   text-decoration: none;
-  background-color: #000;
+  background-color: #000000;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
@@ -4071,28 +4071,28 @@ input[type="submit"].btn.btn-mini {
   left: 50%;
   margin-left: -5px;
   border-width: 5px 5px 0;
-  border-top-color: #000;
+  border-top-color: #000000;
 }
 .tooltip.right .tooltip-arrow {
   top: 50%;
   left: 0;
   margin-top: -5px;
   border-width: 5px 5px 5px 0;
-  border-right-color: #000;
+  border-right-color: #000000;
 }
 .tooltip.left .tooltip-arrow {
   top: 50%;
   right: 0;
   margin-top: -5px;
   border-width: 5px 0 5px 5px;
-  border-left-color: #000;
+  border-left-color: #000000;
 }
 .tooltip.bottom .tooltip-arrow {
   top: 0;
   left: 50%;
   margin-left: -5px;
   border-width: 0 5px 5px;
-  border-bottom-color: #000;
+  border-bottom-color: #000000;
 }
 .thumbnails {
   margin-left: -20px;
@@ -4147,7 +4147,7 @@ a.thumbnail:focus {
 }
 .thumbnail .caption {
   padding: 9px;
-  color: #555;
+  color: #555555;
 }
 .label,
 .badge {
@@ -4156,11 +4156,11 @@ a.thumbnail:focus {
   font-size: 11.844px;
   font-weight: bold;
   line-height: 14px;
-  color: #fff;
+  color: #ffffff;
   vertical-align: baseline;
   white-space: nowrap;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-  background-color: #999;
+  background-color: #999999;
 }
 .label {
   -webkit-border-radius: 3px;
@@ -4182,7 +4182,7 @@ a.label:hover,
 a.label:focus,
 a.badge:hover,
 a.badge:focus {
-  color: #fff;
+  color: #ffffff;
   text-decoration: none;
   cursor: pointer;
 }
@@ -4220,7 +4220,7 @@ a.badge:focus {
 }
 .label-inverse,
 .badge-inverse {
-  background-color: #333;
+  background-color: #333333;
 }
 .label-inverse[href],
 .badge-inverse[href] {
@@ -4297,7 +4297,7 @@ a.badge:focus {
 .progress .bar {
   width: 0%;
   height: 100%;
-  color: #fff;
+  color: #ffffff;
   float: left;
   font-size: 12px;
   text-align: center;
@@ -4512,10 +4512,10 @@ a.badge:focus {
   font-size: 60px;
   font-weight: 100;
   line-height: 30px;
-  color: #fff;
+  color: #ffffff;
   text-align: center;
-  background: #222;
-  border: 3px solid #fff;
+  background: #222222;
+  border: 3px solid #ffffff;
   -webkit-border-radius: 23px;
   -moz-border-radius: 23px;
   border-radius: 23px;
@@ -4528,7 +4528,7 @@ a.badge:focus {
 }
 .carousel-control:hover,
 .carousel-control:focus {
-  color: #fff;
+  color: #ffffff;
   text-decoration: none;
   opacity: 0.9;
   filter: alpha(opacity=90);
@@ -4561,12 +4561,12 @@ a.badge:focus {
   right: 0;
   bottom: 0;
   padding: 15px;
-  background: #333;
+  background: #333333;
   background: rgba(0, 0, 0, 0.75);
 }
 .carousel-caption h4,
 .carousel-caption p {
-  color: #fff;
+  color: #ffffff;
   line-height: 20px;
 }
 .carousel-caption h4 {
@@ -4582,7 +4582,7 @@ a.badge:focus {
   font-weight: 200;
   line-height: 30px;
   color: inherit;
-  background-color: #eee;
+  background-color: #eeeeee;
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
   border-radius: 6px;
@@ -4606,7 +4606,7 @@ a.badge:focus {
   max-width: 276px;
   padding: 1px;
   text-align: left;
-  background-color: #fff;
+  background-color: #ffffff;
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding;
   background-clip: padding-box;
@@ -4678,7 +4678,7 @@ a.badge:focus {
   bottom: 1px;
   margin-left: -10px;
   border-bottom-width: 0;
-  border-top-color: #fff;
+  border-top-color: #ffffff;
 }
 .popover.right .arrow {
   top: 50%;
@@ -4692,7 +4692,7 @@ a.badge:focus {
   left: 1px;
   bottom: -10px;
   border-left-width: 0;
-  border-right-color: #fff;
+  border-right-color: #ffffff;
 }
 .popover.bottom .arrow {
   left: 50%;
@@ -4706,7 +4706,7 @@ a.badge:focus {
   top: 1px;
   margin-left: -10px;
   border-top-width: 0;
-  border-bottom-color: #fff;
+  border-bottom-color: #ffffff;
 }
 .popover.left .arrow {
   top: 50%;
@@ -4719,7 +4719,7 @@ a.badge:focus {
 .popover.left .arrow:after {
   right: 1px;
   border-right-width: 0;
-  border-left-color: #fff;
+  border-left-color: #ffffff;
   bottom: -10px;
 }
 .pull-right {
@@ -5339,14 +5339,14 @@ a.badge:focus {
     display: none;
   }
   .nav-collapse .nav .nav-header {
-    color: #777;
+    color: #777777;
     text-shadow: none;
   }
   .nav-collapse .nav > li > a,
   .nav-collapse .dropdown-menu a {
     padding: 9px 15px;
     font-weight: bold;
-    color: #777;
+    color: #777777;
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
     border-radius: 3px;
@@ -5369,7 +5369,7 @@ a.badge:focus {
   }
   .navbar-inverse .nav-collapse .nav > li > a,
   .navbar-inverse .nav-collapse .dropdown-menu a {
-    color: #999;
+    color: #999999;
   }
   .navbar-inverse .nav-collapse .nav > li > a:hover,
   .navbar-inverse .nav-collapse .nav > li > a:focus,
@@ -5446,7 +5446,7 @@ a.badge:focus {
     padding-right: 10px;
   }
 }
-@media (min-width: 980px) {
+@media (min-width: 979px + 1) {
   .nav-collapse.collapse {
     height: auto !important;
     overflow: visible !important;
@@ -5488,7 +5488,7 @@ a.tag:hover {
 .pill {
   display: inline-block;
   background-color: #6f8890;
-  color: #FFF;
+  color: #ffffff;
   padding: 2px 10px 1px 10px;
   margin-right: 5px;
   font-weight: normal;
@@ -5497,7 +5497,7 @@ a.tag:hover {
   border-radius: 100px;
 }
 .pill a {
-  color: #FFF;
+  color: #ffffff;
 }
 .pill a.remove {
   font-size: 11px;
@@ -5510,7 +5510,7 @@ a.tag:hover {
   font-size: 12px;
   line-height: 1.16666667em;
   padding: 7px 25px;
-  border-bottom: 1px dotted #ddd;
+  border-bottom: 1px dotted #dddddd;
 }
 .simple-item:last-of-type {
   border-bottom: 0;
@@ -5533,7 +5533,7 @@ a.tag:hover {
   font-size: 12px;
   line-height: 1.16666667em;
   padding: 7px 25px;
-  border-bottom: 1px dotted #ddd;
+  border-bottom: 1px dotted #dddddd;
 }
 .simple-list > li:last-of-type {
   border-bottom: 0;
@@ -5563,7 +5563,7 @@ a.tag:hover {
 }
 .box {
   background-color: #FFF;
-  border: 1px solid #CCCCCC;
+  border: 1px solid #cccccc;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
@@ -5581,8 +5581,8 @@ a.tag:hover {
   font-size: 14px;
   line-height: 1.3;
   background-color: #f6f6f6;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #dddddd;
+  border-bottom: 1px solid #dddddd;
 }
 .module-heading:before,
 .module-heading:after {
@@ -5625,16 +5625,16 @@ a.tag:hover {
 .module-footer {
   padding: 7px 25px 7px;
   margin: 0;
-  border-top: 1px dotted #ddd;
+  border-top: 1px dotted #dddddd;
 }
 .module .read-more {
   font-weight: bold;
-  color: #000;
+  color: #000000;
 }
 .module .pagination {
   height: 34px;
   margin-bottom: 0;
-  border-top: 1px solid #ddd;
+  border-top: 1px solid #dddddd;
 }
 .module-content .pagination {
   margin-left: -25px;
@@ -5708,7 +5708,7 @@ a.tag:hover {
   margin: 0 -25px;
   padding-bottom: 15px;
   background: #fbfbfb url("../../../base/images/bg.png");
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   border-width: 1px 0;
 }
 .module-grid:before,
@@ -5791,8 +5791,8 @@ a.tag:hover {
   margin-bottom: 10px;
 }
 .module-resource {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #ddd;
+  background-color: #ffffff;
+  border-bottom: 1px solid #dddddd;
   margin-top: 0;
   margin-bottom: 0;
   -webkit-border-radius: 3px 3px 0 0;
@@ -5843,7 +5843,7 @@ a.tag:hover {
   top: 15px;
   right: -35px;
   width: 80px;
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #117799;
   padding: 1px 20px;
   font-size: 11px;
@@ -5857,7 +5857,7 @@ a.tag:hover {
   margin: 0 -25px;
   padding-bottom: 15px;
   background: #fbfbfb url("../../../base/images/bg.png");
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   border-width: 1px 0;
 }
 .media-grid:before,
@@ -5913,7 +5913,7 @@ a.tag:hover {
   left: 0;
   right: 0;
   bottom: 0;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   overflow: hidden;
   -webkit-transition: all 0.2s ease-in;
   -moz-transition: all 0.2s ease-in;
@@ -6032,7 +6032,7 @@ a.tag:hover {
   font-size: 12px;
   line-height: 1.16666667em;
   padding: 7px 25px;
-  border-bottom: 1px dotted #ddd;
+  border-bottom: 1px dotted #dddddd;
 }
 .nav-simple > li:last-of-type,
 .nav-aside > li:last-of-type {
@@ -6050,7 +6050,7 @@ a.tag:hover {
 }
 .nav-item > a,
 .nav-aside li a {
-  color: #333;
+  color: #333333;
   font-size: 14px;
   line-height: 20px;
   margin: -7px -25px;
@@ -6063,13 +6063,13 @@ a.tag:hover {
 .nav-item.active > a,
 .nav-aside li.active a {
   position: relative;
-  color: #FFF;
-  background-color: #8CA0A6;
+  color: #ffffff;
+  background-color: #8ca0a6;
 }
 .nav-item.active > a:hover,
 .nav-aside li.active a:hover {
-  color: #FFF;
-  background-color: #8CA0A6;
+  color: #ffffff;
+  background-color: #8ca0a6;
 }
 @media (min-width: 768px) {
   .nav-item.active > a:before,
@@ -6357,7 +6357,7 @@ textarea {
   position: relative;
   display: block;
   font-size: 11px;
-  color: #aaa;
+  color: #aaaaaa;
   line-height: 1.3;
   margin-top: 6px;
 }
@@ -6400,7 +6400,7 @@ textarea {
   margin-right: 15px;
 }
 .form-horizontal .info-block a {
-  color: #aaa;
+  color: #aaaaaa;
   text-decoration: underline;
 }
 .form-horizontal .form-actions {
@@ -6438,7 +6438,7 @@ textarea {
   position: relative;
 }
 .simple-input .field-bordered {
-  border-bottom: 1px dotted #ddd;
+  border-bottom: 1px dotted #dddddd;
 }
 .simple-input .field input {
   width: 100%;
@@ -6481,7 +6481,7 @@ textarea {
   padding: 4px 10px;
   background: #ebebeb;
   width: auto;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-top: none;
   font-size: 11px;
   color: #282828;
@@ -6533,7 +6533,7 @@ textarea {
 }
 .control-custom.disabled label,
 .control-custom.disabled input {
-  color: #aaa;
+  color: #aaaaaa;
   text-decoration: line-through;
   text-shadow: none;
 }
@@ -6573,7 +6573,7 @@ textarea {
   display: none;
 }
 .control-custom.disabled .checkbox.btn {
-  color: #fff;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #206b82;
   background-image: -moz-linear-gradient(top, #30778d, #085871);
@@ -6595,7 +6595,7 @@ textarea {
 .control-custom.disabled .checkbox.btn.active,
 .control-custom.disabled .checkbox.btn.disabled,
 .control-custom.disabled .checkbox.btn[disabled] {
-  color: #fff;
+  color: #ffffff;
   background-color: #085871;
   *background-color: #064559;
 }
@@ -6604,8 +6604,8 @@ textarea {
   background-color: #053341 \9;
 }
 .control-custom.disabled .checkbox.btn .caret {
-  border-top-color: #fff;
-  border-bottom-color: #fff;
+  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
 }
 .alert-danger a,
 .alert-error a {
@@ -6633,7 +6633,7 @@ textarea {
   padding: 6px 8px 3px;
   background: #c6898b;
   margin: -3px 0 0;
-  color: #fff;
+  color: #ffffff;
   width: 208px;
 }
 .control-medium .error-block {
@@ -6677,7 +6677,7 @@ textarea {
   line-height: 27px;
   counter-increment: stage;
   width: 50%;
-  background-color: #EDEDED;
+  background-color: #ededed;
   float: left;
   padding: 10px 20px;
   position: relative;
@@ -6694,7 +6694,7 @@ textarea {
   margin-right: 5px;
   font-weight: bold;
   text-align: center;
-  color: #fff;
+  color: #ffffff;
   background-color: #aeaeae;
   z-index: 1;
 }
@@ -6706,8 +6706,8 @@ textarea {
   width: 0;
   position: absolute;
   pointer-events: none;
-  border-top-color: #EDEDED;
-  border-bottom-color: #EDEDED;
+  border-top-color: #ededed;
+  border-bottom-color: #ededed;
   border-width: 29px;
   top: 50%;
   margin-top: -29px;
@@ -6746,7 +6746,7 @@ textarea {
 }
 .stages li.active:before {
   color: #8cc68a;
-  background: #fff;
+  background: #ffffff;
 }
 .stages li.complete:before {
   color: #c5e2c4;
@@ -6773,7 +6773,7 @@ textarea {
   }
 }
 .stages li.active .highlight {
-  color: #fff;
+  color: #ffffff;
   background: #8cc68a;
 }
 .stages li.complete .highlight {
@@ -6861,8 +6861,8 @@ textarea {
   -moz-transition: border linear 0.2s, box-shadow linear 0.2s;
   -o-transition: border linear 0.2s, box-shadow linear 0.2s;
   transition: border linear 0.2s, box-shadow linear 0.2s;
-  background-color: #fff;
-  border: 1px solid #ccc;
+  background-color: #ffffff;
+  border: 1px solid #cccccc;
 }
 .select2-container-active .select2-choices,
 .select2-container-multi.select2-container-active .select2-choices {
@@ -6911,7 +6911,7 @@ textarea {
   margin-right: 10px;
 }
 .js .image-upload .btn.hover {
-  color: #333;
+  color: #333333;
   text-decoration: none;
   background-position: 0 -15px;
   -webkit-transition: background-position 0.1s linear;
@@ -6945,7 +6945,7 @@ textarea {
   width: 7%;
   text-align: center;
   text-transform: uppercase;
-  color: #999;
+  color: #999999;
   font-weight: bold;
 }
 .add-member-form .row-fluid .control-group {
@@ -6961,7 +6961,7 @@ textarea {
   line-height: 1;
 }
 .dataset-item {
-  border-bottom: 1px dotted #ddd;
+  border-bottom: 1px dotted #dddddd;
   padding-bottom: 20px;
   margin-bottom: 20px;
 }
@@ -6982,7 +6982,7 @@ textarea {
   line-height: 1.3;
 }
 .dataset-heading a {
-  color: #333;
+  color: #333333;
 }
 .dataset-heading .label {
   position: relative;
@@ -7005,7 +7005,7 @@ textarea {
   display: inline;
 }
 .dataset-resources li a {
-  background-color: #aaa;
+  background-color: #aaaaaa;
 }
 .dataset-heading .popular {
   top: 0;
@@ -7024,10 +7024,10 @@ textarea {
   border-radius: 3px;
 }
 .resource-item:hover {
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
 }
 .resource-item .heading {
-  color: #000;
+  color: #000000;
   font-size: 14px;
   font-weight: bold;
 }
@@ -7052,14 +7052,14 @@ textarea {
   }
 }
 .resource-list.reordering .resource-item {
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   margin-bottom: 10px;
   cursor: move;
 }
 .resource-list.reordering .resource-item .handle {
   display: block;
   position: absolute;
-  color: #888;
+  color: #888888;
   left: -31px;
   top: 50%;
   margin-top: -15px;
@@ -7067,9 +7067,9 @@ textarea {
   height: 30px;
   line-height: 30px;
   text-align: center;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   border-width: 1px 0 1px 1px;
-  background-color: #fff;
+  background-color: #ffffff;
   -webkit-border-radius: 20px 0 0 20px;
   -moz-border-radius: 20px 0 0 20px;
   border-radius: 20px 0 0 20px;
@@ -7078,16 +7078,16 @@ textarea {
   text-decoration: none;
 }
 .resource-list.reordering .resource-item:hover .handle {
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
 }
 .resource-list.reordering .resource-item.ui-sortable-helper {
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
   border: 1px solid #004a61;
 }
 .resource-list.reordering .resource-item.ui-sortable-helper .handle {
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
   border-color: #004a61;
-  color: #333;
+  color: #333333;
 }
 .resource-item .handle {
   display: none;
@@ -7120,7 +7120,7 @@ textarea {
   display: block;
   min-height: 50px;
   padding: 10px;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   overflow: hidden;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
@@ -7133,7 +7133,7 @@ textarea {
   overflow: hidden;
   margin-right: 10px;
   color: #333333;
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -7145,7 +7145,7 @@ textarea {
   line-height: 50px;
 }
 .view-list li a h3 {
-  color: #000;
+  color: #000000;
   font-weight: bold;
   font-size: 16px;
   margin: 0 0 3px 0;
@@ -7222,7 +7222,7 @@ textarea {
 .search-form {
   margin-bottom: 20px;
   padding-bottom: 25px;
-  border-bottom: 1px dotted #ddd;
+  border-bottom: 1px dotted #dddddd;
 }
 .search-form .search-input {
   position: relative;
@@ -7252,14 +7252,14 @@ textarea {
   display: none;
 }
 .search-form .search-input button i {
-  color: #ccc;
+  color: #cccccc;
   -webkit-transition: color 0.2s ease-in;
   -moz-transition: color 0.2s ease-in;
   -o-transition: color 0.2s ease-in;
   transition: color 0.2s ease-in;
 }
 .search-form .search-input button:hover i {
-  color: #000;
+  color: #000000;
 }
 .search-form .search-input.search-giant input {
   font-size: 16px;
@@ -7285,7 +7285,7 @@ textarea {
 .search-form h2 {
   font-size: 24px;
   line-height: 1.3;
-  color: #000;
+  color: #000000;
   margin-bottom: 0;
   margin-top: 20px;
 }
@@ -7301,7 +7301,7 @@ textarea {
   margin-top: 10px;
   font-size: 18px;
   font-weight: normal;
-  color: #000;
+  color: #000000;
 }
 .search-form.no-bottom-border {
   border-bottom-width: 0;
@@ -7367,7 +7367,7 @@ a.search-context-switch:hover {
   margin-bottom: 2px;
 }
 .group-list .module-heading h3 a {
-  color: #333;
+  color: #333333;
 }
 .group-list .module-heading .media-image {
   overflow: hidden;
@@ -7475,7 +7475,7 @@ a.search-context-switch:hover {
 }
 .page-header {
   *zoom: 1;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid #dddddd;
   background-color: #f6f6f6;
   -webkit-border-radius: 0 3px 0 0;
   -moz-border-radius: 0 3px 0 0;
@@ -7496,7 +7496,7 @@ a.search-context-switch:hover {
 }
 .page-header .nav-tabs li.active a,
 .page-header .nav-tabs a:hover {
-  background-color: #fff;
+  background-color: #ffffff;
 }
 .page-header .content_action {
   float: right;
@@ -7513,7 +7513,7 @@ a.search-context-switch:hover {
 }
 .nav-tabs-plain > .active > a,
 .nav-tabs-plain > .active > a:hover {
-  background-color: #fff;
+  background-color: #ffffff;
 }
 @media (min-width: 768px) {
   .span9 .page-header {
@@ -7579,8 +7579,8 @@ h4 small {
 }
 .table-chunky thead th,
 .table-chunky thead td {
-  color: #FFFFFF;
-  background-color: #AAAAAA;
+  color: #ffffff;
+  background-color: #aaaaaa;
   padding-top: 10px;
   padding-bottom: 10px;
 }
@@ -7590,7 +7590,7 @@ h4 small {
 }
 .table-striped tbody tr:nth-child(even) td,
 .table-striped tbody tr:nth-child(even) th {
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
 }
 .table-chunky.table-bordered {
   -webkit-border-radius: 2px;
@@ -7941,7 +7941,7 @@ h4 small {
 .wrapper {
   *zoom: 1;
   background-color: #FFF;
-  border: 1px solid #CCCCCC;
+  border: 1px solid #cccccc;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
@@ -7986,7 +7986,7 @@ h4 small {
   [role=main],
   .main {
     padding-top: 10px;
-    background: #EEEEEE url("../../../base/images/bg.png");
+    background: #eeeeee url("../../../base/images/bg.png");
   }
 }
 [role=main] {
@@ -8213,9 +8213,9 @@ h4 small {
   margin-top: 0;
 }
 .flash-messages .alert {
-  -webkit-box-shadow: 0 0 0 1px white;
-  -moz-box-shadow: 0 0 0 1px white;
-  box-shadow: 0 0 0 1px white;
+  -webkit-box-shadow: 0 0 0 1px #ffffff;
+  -moz-box-shadow: 0 0 0 1px #ffffff;
+  box-shadow: 0 0 0 1px #ffffff;
 }
 .homepage .row {
   position: relative;
@@ -8223,8 +8223,8 @@ h4 small {
 .homepage .module-search {
   padding: 5px;
   margin: 20px 0 0 0;
-  color: #FFFFFF;
-  background: #FFFFFF;
+  color: #ffffff;
+  background: #ffffff;
 }
 .homepage .module-search .search-giant {
   margin-bottom: 10px;
@@ -8330,10 +8330,29 @@ h4 small {
     right: 0;
   }
 }
+div.masthead {
+  background-color: #117799;
+  background-image: none;
+  color: #fff;
+  min-height: 55px;
+  margin-top: 20px;
+}
+div.masthead a {
+  border-bottom: none;
+  color: #ffffff;
+  text-decoration: none;
+}
+div.masthead .container {
+  position: relative;
+  width: 940px;
+}
+div.not-authored {
+  width: 500px;
+}
 .account-masthead {
   *zoom: 1;
   min-height: 30px;
-  color: #FFFFFF;
+  color: #ffffff;
   background: #0c536b url("../../../base/images/bg.png");
 }
 .account-masthead:before,
@@ -8406,12 +8425,12 @@ h4 small {
   color: #c4dde6;
 }
 .account-masthead .account .notifications a:hover span {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #07303d;
 }
 .account-masthead .account .notifications.notifications-important a span.badge {
-  color: #FFFFFF;
-  background-color: #C9403A;
+  color: #ffffff;
+  background-color: #c9403a;
 }
 .account-masthead .account.authed .image {
   padding: 0 6px;
@@ -8425,7 +8444,7 @@ h4 small {
 .masthead {
   *zoom: 1;
   min-height: 55px;
-  color: #FFFFFF;
+  color: #ffffff;
   background: #117799 url("../../../base/images/bg.png");
 }
 .masthead:before,
@@ -8441,7 +8460,7 @@ h4 small {
   position: relative;
 }
 .masthead a {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 .masthead hgroup h1,
 .masthead hgroup h2 {
@@ -8585,6 +8604,7 @@ h4 small {
   .masthead .container {
     padding-left: 20px;
     padding-right: 20px;
+    width: 92% !important;
   }
   .masthead .site-search-wrap {
     display: none;
@@ -8592,7 +8612,7 @@ h4 small {
 }
 .site-footer {
   *zoom: 1;
-  color: #FFFFFF;
+  color: #ffffff;
   background: #117799 url("../../../base/images/bg.png");
   background-image: none;
   min-height: 55px;
@@ -8612,7 +8632,7 @@ h4 small {
   position: relative;
 }
 .site-footer a {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 .site-footer hgroup h1,
 .site-footer hgroup h2 {
@@ -8760,7 +8780,7 @@ h4 small {
   -webkit-font-smoothing: antialiased;
 }
 .site-footer a:hover {
-  color: #fff;
+  color: #ffffff;
   text-decoration: underline;
 }
 @media (max-width: 767px) {
@@ -8774,12 +8794,12 @@ h4 small {
 }
 .site-footer h2.footcolheader {
   left: 0;
-  border-top: 1px solid #fff;
+  border-top: 1px solid #ffffff;
   font-size: 1.2rem;
   margin: 0;
   padding: 16px 0 8px;
   position: relative;
-  color: #fff;
+  color: #ffffff;
 }
 .site-footer .footlink {
   margin: 8px 0;
@@ -8797,7 +8817,7 @@ h4 small {
   }
 }
 .site-footer .footsub p {
-  color: #fff;
+  color: #ffffff;
 }
 .site-footer .footsubcol01 p {
   margin-top: 16px;
@@ -8811,7 +8831,7 @@ h4 small {
   padding: 0;
 }
 .site-footer .footright {
-  border-bottom: 1px solid #fff;
+  border-bottom: 1px solid #ffffff;
   clear: both;
   padding: 32px 0;
   text-align: right;
@@ -8823,16 +8843,16 @@ h4 small {
 .site-footer,
 .site-footer label,
 .site-footer small {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 .site-footer a {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 .footer-links ul li {
   margin-bottom: 5px;
 }
 .attribution small {
-  color: #FFFFFF;
+  color: #ffffff;
   font-size: 12px;
 }
 .attribution .ckan-footer-logo {
@@ -8862,7 +8882,7 @@ h4 small {
   margin-top: 0;
 }
 .lang-dropdown {
-  color: #000;
+  color: #000000;
 }
 .lang-dropdown li {
   width: auto;
@@ -8957,7 +8977,7 @@ h4 small {
   height: 30px;
   line-height: 30px;
   text-align: center;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   font-weight: normal;
   margin-right: 10px;
@@ -9043,16 +9063,16 @@ h4 small {
   background-color: #999999;
 }
 .activity .item.failure .icon {
-  background-color: #B95252;
+  background-color: #b95252;
 }
 .activity .item.success .icon {
-  background-color: #69A67A;
+  background-color: #69a67a;
 }
 .activity .item.added-tag .icon {
   background-color: #6995a6;
 }
 .activity .item.changed-group .icon {
-  background-color: #767DCE;
+  background-color: #767dce;
 }
 .activity .item.changed-package .icon {
   background-color: #8c76ce;
@@ -9070,7 +9090,7 @@ h4 small {
   background-color: #699fa6;
 }
 .activity .item.deleted-group .icon {
-  background-color: #B95252;
+  background-color: #b95252;
 }
 .activity .item.deleted-package .icon {
   background-color: #b97452;
@@ -9085,7 +9105,7 @@ h4 small {
   background-color: #b95297;
 }
 .activity .item.new-group .icon {
-  background-color: #69A67A;
+  background-color: #69a67a;
 }
 .activity .item.new-package .icon {
   background-color: #69a68e;
@@ -9109,7 +9129,7 @@ h4 small {
   background-color: #b9b952;
 }
 .activity .item.follow-dataset .icon {
-  background-color: #767DCE;
+  background-color: #767dce;
 }
 .activity .item.follow-user .icon {
   background-color: #8c76ce;
@@ -9196,7 +9216,7 @@ h4 small {
   *zoom: 1;
   background-color: whiteSmoke;
   padding: 5px;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #cccccc;
   -webkit-border-radius: 3px 3px 0 0;
   -moz-border-radius: 3px 3px 0 0;
   border-radius: 3px 3px 0 0;
@@ -9255,7 +9275,7 @@ h4 small {
 }
 .popover-followee .nav li a i {
   background-color: #004a61;
-  color: #fff;
+  color: #ffffff;
   margin-right: 11px;
   padding: 3px 5px;
   line-height: 1;
@@ -9271,7 +9291,7 @@ h4 small {
 }
 .popover-followee .nav li.active a i {
   color: #004a61;
-  background-color: #fff;
+  background-color: #ffffff;
 }
 .dashboard-me {
   *zoom: 1;
@@ -9359,7 +9379,7 @@ body {
   overflow-x: hidden;
 }
 body .notification-bar {
-  background-color: #FFB100;
+  background-color: #ffb100;
   height: auto;
   margin: 0 auto;
   padding: 10px;
@@ -9374,11 +9394,11 @@ body .notification-bar {
 }
 @media (max-width: 768px) {
   body.home {
-    background: #E8E8E8;
+    background: #e8e8e8;
   }
 }
 body.home .masthead {
-  border-bottom: 10px solid #349EB7;
+  border-bottom: 10px solid #349eb7;
 }
 body.home .masthead .navigation {
   margin-right: -25px;
@@ -9389,10 +9409,10 @@ body.home .categories {
 @media (min-width: 768px) {
   body.home .categories .span4 {
     width: 238px;
-    border-right: 1px solid #FFFFFF;
+    border-right: 1px solid #ffffff;
   }
   body.home .categories .span4:first-child {
-    border-left: 1px solid #FFFFFF;
+    border-left: 1px solid #ffffff;
   }
   body.home .categories .span4:nth-child(2),
   body.home .categories .span4:nth-child(3) {
@@ -9405,10 +9425,10 @@ body.home .categories {
   }
   body.home .categories .span4 {
     width: 311px;
-    border-right: 1px solid #FFFFFF;
+    border-right: 1px solid #ffffff;
   }
   body.home .categories .span4:first-child {
-    border-left: 1px solid #FFFFFF;
+    border-left: 1px solid #ffffff;
   }
   body.home .categories .span4:nth-child(2),
   body.home .categories .span4:nth-child(3) {
@@ -9420,7 +9440,7 @@ body.home .info {
 }
 body.home .info .news,
 body.home .info .event {
-  background-color: #E8E8E8;
+  background-color: #e8e8e8;
 }
 body.home .info h2 {
   padding-top: 55px;
@@ -9506,7 +9526,7 @@ body a {
   color: #004a61;
 }
 body a:hover {
-  color: #075D79;
+  color: #075d79;
 }
 body p {
   padding: 15px;
@@ -9524,13 +9544,12 @@ body .icon-building {
 }
 header.account-masthead {
   background: #117799;
-  padding-bottom: 20px;
 }
 header.account-masthead .account.authed .image {
   padding: 5px 6px;
 }
 header.account-masthead .account li.feedback {
-  background-color: #FFB100;
+  background-color: #ffb100;
   color: #333333;
 }
 header.account-masthead .account li.feedback a {
@@ -9538,11 +9557,11 @@ header.account-masthead .account li.feedback a {
   font-weight: normal;
 }
 header.account-masthead .account li.feedback a:hover {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 header.account-masthead .account ul li {
   border: none;
-  background: #004A61;
+  background: #004a61;
 }
 header.account-masthead .account ul li a {
   padding: 5px 15px;
@@ -9624,7 +9643,7 @@ header.account-masthead .account ul li a:hover {
   border: none;
 }
 .homepage .hero .module-search .tags {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   border-radius: 0;
   border: 0;
   -webkit-border-radius: 0;
@@ -9634,7 +9653,7 @@ header.account-masthead .account ul li a:hover {
 @media (max-width: 768px) {
   .homepage .hero .module-search .tags {
     text-align: left;
-    background-color: #EEEEEE;
+    background-color: #eeeeee;
   }
 }
 .homepage .hero .module-search .tags a {
@@ -9644,11 +9663,11 @@ header.account-masthead .account ul li a:hover {
   max-height: 30px;
 }
 .homepage .hero .module-search .tags a:hover {
-  background-color: #075D79;
-  color: #FFFFFF;
+  background-color: #075d79;
+  color: #ffffff;
 }
 .homepage .hero .module-search .tags a:hover:before {
-  border-right-color: #075D79;
+  border-right-color: #075d79;
 }
 .homepage .hero .module-search .tags a:before {
   content: "";
@@ -9673,7 +9692,7 @@ header.account-masthead .account ul li a:hover {
 .homepage .hero .module-search .tags .tag {
   float: right;
   border-radius: 0;
-  background-color: #BADAE2;
+  background-color: #badae2;
   box-shadow: none;
   padding: 3px 10px;
   margin: 5px 5px 5px 15px;
@@ -9690,11 +9709,11 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .hero .module-search .module-content .heading,
 .homepage .hero .module-search .tags .heading {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 .homepage .hero .module-search .module-content h3,
 .homepage .hero .module-search .tags h3 {
-  color: #FFFFFF;
+  color: #ffffff;
   float: none;
 }
 .site-footer {
@@ -9709,9 +9728,9 @@ header.account-masthead .account ul li a:hover {
   margin-top: 0;
 }
 .homepage .categories .module-content.land {
-  background: #00789A;
+  background: #00789a;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.land h3 {
@@ -9726,7 +9745,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.land h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -9751,7 +9770,7 @@ header.account-masthead .account ul li a:hover {
 .homepage .categories .module-content.health {
   background: #005e7a;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.health h3 {
@@ -9766,7 +9785,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.health h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -9789,9 +9808,9 @@ header.account-masthead .account ul li a:hover {
   }
 }
 .homepage .categories .module-content.government {
-  background: #004A61;
+  background: #004a61;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.government h3 {
@@ -9806,7 +9825,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.government h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -9829,9 +9848,9 @@ header.account-masthead .account ul li a:hover {
   }
 }
 .homepage .categories .module-content.environment {
-  background: #FFB100;
+  background: #ffb100;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.environment h3 {
@@ -9846,7 +9865,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.environment h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -9869,9 +9888,9 @@ header.account-masthead .account ul li a:hover {
   }
 }
 .homepage .categories .module-content.transport {
-  background: #CC8900;
+  background: #cc8900;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.transport h3 {
@@ -9886,7 +9905,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.transport h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -9909,9 +9928,9 @@ header.account-masthead .account ul li a:hover {
   }
 }
 .homepage .categories .module-content.education {
-  background: #A16B00;
+  background: #a16b00;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.education h3 {
@@ -9926,7 +9945,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.education h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -9949,9 +9968,9 @@ header.account-masthead .account ul li a:hover {
   }
 }
 .homepage .categories .module-content.state {
-  background: #FF8400;
+  background: #ff8400;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.state h3 {
@@ -9966,7 +9985,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.state h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -9989,9 +10008,9 @@ header.account-masthead .account ul li a:hover {
   }
 }
 .homepage .categories .module-content.population {
-  background: #CE6300;
+  background: #ce6300;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.population h3 {
@@ -10006,7 +10025,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.population h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -10029,9 +10048,9 @@ header.account-masthead .account ul li a:hover {
   }
 }
 .homepage .categories .module-content.arts {
-  background: #A34D00;
+  background: #a34d00;
   padding: 0;
-  border-bottom: 1px solid #FFFFFF;
+  border-bottom: 1px solid #ffffff;
   margin-bottom: 0;
 }
 .homepage .categories .module-content.arts h3 {
@@ -10046,7 +10065,7 @@ header.account-masthead .account ul li a:hover {
 }
 .homepage .categories .module-content.arts h3 a {
   position: relative;
-  color: #FFFFFF;
+  color: #ffffff;
   text-decoration: none;
   display: block;
   padding-right: 20px;
@@ -10115,19 +10134,19 @@ header.account-masthead .account ul li a:hover {
   font-size: 16px;
 }
 .homepage .stats ul li:nth-child(1) a {
-  background-color: #0084A0;
+  background-color: #0084a0;
 }
 .homepage .stats ul li:nth-child(2) a {
-  background-color: #005E7A;
+  background-color: #005e7a;
 }
 .homepage .stats ul li:nth-child(3) a {
-  background-color: #004A61;
+  background-color: #004a61;
 }
 .homepage .stats ul li:nth-child(4) a {
   background-color: #003648;
 }
 .homepage .stats ul li a {
-  color: #FFFFFF;
+  color: #ffffff;
   text-align: center;
   display: inline-block;
   height: 90px;
@@ -10159,13 +10178,13 @@ header.account-masthead .account ul li a:hover {
 }
 .toolbar {
   background-color: #0c536b;
-  color: #FFFFFF;
+  color: #ffffff;
   /* add back negative margin value */
   padding: 0.25rem 9999rem;
   margin: -10px -9999rem 0;
 }
 .toolbar .breadcrumb > li > a {
-  color: #FFFFFF;
+  color: #ffffff;
   font-size: 14px;
   text-shadow: none;
 }
@@ -10186,7 +10205,7 @@ header.account-masthead .account ul li a:hover {
   padding-right: 5px;
 }
 .wrapper {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   border: none;
   -webkit-border-radius: 0;
   -moz-border-radius: 0;
@@ -10207,18 +10226,18 @@ header.account-masthead .account ul li a:hover {
 }
 .primary header.module-content.page-header {
   border-bottom: 1px solid #117799;
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
   margin-left: 0;
 }
 @media (min-width: 768px) {
   .primary header.module-content.page-header {
-    background-color: #FFFFFF;
+    background-color: #ffffff;
     width: 100%;
   }
 }
 .primary .page-header .nav-tabs li.active a,
 .primary .page-header .nav-tabs a:active {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #117799;
   border: 1px solid #117799;
 }
@@ -10226,7 +10245,7 @@ header.account-masthead .account ul li a:hover {
   color: #117799;
 }
 .primary .nav-tabs > li > a:hover {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #117799;
 }
 .primary .nav-tabs {
@@ -10234,7 +10253,7 @@ header.account-masthead .account ul li a:hover {
 }
 @media (max-width: 768px) {
   .primary .nav-tabs {
-    color: #EEEEEE;
+    color: #eeeeee;
     border: none;
   }
 }
@@ -10252,18 +10271,18 @@ header.account-masthead .account ul li a:hover {
   text-decoration: underline;
 }
 .primary .resource-list li.resource-item {
-  border-top: 1px solid #CCCCCC;
+  border-top: 1px solid #cccccc;
   border-radius: 0;
 }
 .primary .resource-list li.resource-item:last-child {
-  border-bottom: 1px solid #CCCCCC;
+  border-bottom: 1px solid #cccccc;
   border-radius: 0;
 }
 .primary .dataset-resources li a {
   background: #117799;
 }
 .primary .btn.btn-primary {
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #004a61;
   border: 0;
@@ -10286,7 +10305,7 @@ header.account-masthead .account ul li a:hover {
   margin-right: -10px;
 }
 .primary .tag-list.well {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   border-radius: 0;
   border: 0;
   -webkit-border-radius: 0;
@@ -10297,7 +10316,7 @@ header.account-masthead .account ul li a:hover {
 }
 @media (max-width: 768px) {
   .primary .tag-list.well {
-    background-color: #EEEEEE;
+    background-color: #eeeeee;
   }
 }
 .primary .tag-list.well a {
@@ -10307,11 +10326,11 @@ header.account-masthead .account ul li a:hover {
   max-height: 30px;
 }
 .primary .tag-list.well a:hover {
-  background-color: #075D79;
-  color: #FFFFFF;
+  background-color: #075d79;
+  color: #ffffff;
 }
 .primary .tag-list.well a:hover:before {
-  border-right-color: #075D79;
+  border-right-color: #075d79;
 }
 .primary .tag-list.well a:before {
   content: "";
@@ -10332,7 +10351,7 @@ header.account-masthead .account ul li a:hover {
   font-size: 14px;
   padding: 5px 10px;
   color: #004a61;
-  background-color: #BADAE2;
+  background-color: #badae2;
   border: 0;
   -webkit-border-radius: 0;
   -moz-border-radius: 0;
@@ -10344,13 +10363,13 @@ header.account-masthead .account ul li a:hover {
   padding-top: 30px;
 }
 .primary .additional-info .table {
-  border-bottom: 1px solid #CCCCCC;
+  border-bottom: 1px solid #cccccc;
   border-right: 0;
   border-radius: 0;
   font-size: 14px;
 }
 .primary .additional-info thead th {
-  border-bottom: 1px solid #CCCCCC;
+  border-bottom: 1px solid #cccccc;
 }
 .primary .additional-info .table-bordered th,
 .primary .additional-info .table-bordered td {
@@ -10362,12 +10381,12 @@ header.account-masthead .account ul li a:hover {
   border-top: 0;
 }
 aside.secondary .module.module-narrow {
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
 }
 aside.secondary .module.module-narrow h1.heading {
   margin: 0 0 0 0;
-  background-color: #004A61;
-  color: #FFFFFF;
+  background-color: #004a61;
+  color: #ffffff;
   padding: 15px;
   font-size: 16px;
 }
@@ -10397,7 +10416,7 @@ aside.secondary .module.module-narrow img {
 aside.secondary .module.module-narrow .nums {
   margin-top: 0;
   border-top: 0;
-  background-color: #EDF9FD;
+  background-color: #edf9fd;
   padding: 15px;
 }
 aside.secondary .module.module-narrow .nums dl {
@@ -10419,7 +10438,7 @@ aside.secondary .module.module-narrow .context-info:after {
   height: 0;
   border-style: solid;
   border-width: 10px 0 10px 15px;
-  border-color: transparent transparent transparent #004A61;
+  border-color: transparent transparent transparent #004a61;
   display: block;
   top: 65px;
   left: 220px;
@@ -10437,7 +10456,7 @@ aside.secondary .module.module-narrow .context-info:after {
 aside.secondary .module.module-narrow h2.module-heading {
   padding-left: 15px;
   border: none;
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
 }
 aside.secondary .module.module-narrow h2.module-heading .action {
   color: #333333;
@@ -10454,7 +10473,7 @@ aside.secondary .module.module-narrow .nav-aside > li {
   margin: 0;
   padding: 0;
   width: auto;
-  border-bottom: 1px dotted #CCCCCC;
+  border-bottom: 1px dotted #cccccc;
 }
 aside.secondary .module.module-narrow .nav-simple > li a,
 aside.secondary .module.module-narrow .nav-aside > li a {
@@ -10479,43 +10498,43 @@ aside.secondary .module.module-narrow.social .icon-google-plus-sign {
   border-radius: 100%;
   padding: 12px;
   font-size: 20px;
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #117799;
 }
 aside.secondary .module.module-narrow.social .icon-google-plus-sign:before {
   content: "\f0d5";
 }
 aside.secondary .module.module-narrow.social .icon-google-plus-sign:hover {
-  background-color: #075D79;
+  background-color: #075d79;
 }
 aside.secondary .module.module-narrow.social .icon-twitter-sign {
   border-radius: 100%;
   padding: 12px;
   font-size: 20px;
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #117799;
 }
 aside.secondary .module.module-narrow.social .icon-twitter-sign:before {
   content: "\f099";
 }
 aside.secondary .module.module-narrow.social .icon-twitter-sign:hover {
-  background-color: #075D79;
+  background-color: #075d79;
 }
 aside.secondary .module.module-narrow.social .icon-facebook-sign {
   border-radius: 100%;
   padding: 12px;
   font-size: 20px;
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #117799;
 }
 aside.secondary .module.module-narrow.social .icon-facebook-sign:before {
   content: "\f082";
 }
 aside.secondary .module.module-narrow.social .icon-facebook-sign:hover {
-  background-color: #075D79;
+  background-color: #075d79;
 }
 aside.secondary .module.module-narrow.social .nav-simple {
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
   padding-bottom: 10px;
 }
 aside.secondary .module.module-narrow.social .nav-simple > li {
@@ -10561,7 +10580,7 @@ table .metric {
   width: 140px;
 }
 code {
-  color: #000;
+  color: #000000;
   border: none;
   background: none;
   white-space: normal;
@@ -10594,7 +10613,7 @@ iframe {
   text-indent: -999em;
 }
 .empty {
-  color: #aaa;
+  color: #aaaaaa;
   font-style: italic;
 }
 .page-heading {
@@ -10682,7 +10701,7 @@ iframe {
 .ie8 .main,
 .ie7 .main {
   padding-top: 10px;
-  background: #EEEEEE url("../../../base/images/bg.png");
+  background: #eeeeee url("../../../base/images/bg.png");
 }
 .ie8 .hero,
 .ie7 .hero {
@@ -10761,7 +10780,7 @@ iframe {
 }
 .ie7 .stages {
   overflow: hidden;
-  background-color: #EDEDED;
+  background-color: #ededed;
 }
 .ie7 .stages li {
   height: 30px;

--- a/ckanext/dia_theme/less/dia_custom.less
+++ b/ckanext/dia_theme/less/dia_custom.less
@@ -313,7 +313,6 @@ body {
 //==============================================
 header.account-masthead {
   background: @mastheadBackgroundColor;
-  padding-bottom: 20px;
 
   .account.authed .image {
     padding: 5px 6px;

--- a/ckanext/dia_theme/less/masthead.less
+++ b/ckanext/dia_theme/less/masthead.less
@@ -1,5 +1,27 @@
 @notificationsBg: #C9403A;
 
+div {
+  &.masthead {
+    background-color:#117799;
+    background-image: none;
+    color:#fff;
+    min-height: 55px;
+    margin-top: 20px;
+    a {
+      border-bottom:none;
+      color: #ffffff;
+      text-decoration: none;
+    }
+    .container{
+      position: relative;
+      width:940px;
+    }
+  }
+  &.not-authored {
+    width: 500px;
+  }
+}
+
 .account-masthead {
   .clearfix();
   min-height: 30px;
@@ -250,6 +272,7 @@
     .container {
       padding-left:20px;
       padding-right:20px;
+      width: 92% !important;
     }
     .site-search-wrap {
       display:none;

--- a/ckanext/dia_theme/templates/header_base.html
+++ b/ckanext/dia_theme/templates/header_base.html
@@ -1,11 +1,11 @@
 {# This is copied from the CKAN source, with header_site_search moved outside .nav-collapse, and accessibility changes as per wr267900 #}
 {% block header_wrapper %}
     {% block header_account %}
-        <header class="account-masthead">
+        <header class="account-masthead" role="banner">
             <div class="container">
                 {% block header_account_container_content %}
                     {% if c.userobj %}
-                        <div class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
+                        <nav class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}" role="navigation" aria-label="Add/request dataset">
                             <ul class="unstyled">
                                 {% block header_account_logged %}
                                     {% if c.userobj.sysadmin %}
@@ -49,9 +49,9 @@
                                     {% endblock %}
                                 {% endblock %}
                             </ul>
-                        </div>
+                        </nav>
                     {% else %}
-                        <nav class="account not-authed">
+                        <nav class="account not-authed" role="navigation" aria-label="Login/Register">
                             <ul class="unstyled">
                                 {% block header_account_notlogged %}
                                     <li>{% link_for _('Log in'), controller='user', action='login' %}</li>
@@ -64,9 +64,8 @@
                     {% endif %}
                 {% endblock %}
             </div>
-        </header>
     {% endblock %}
-    <header class="navbar navbar-static-top masthead">
+    <div class="navbar navbar-static-top masthead">
         {% block header_debug %}
             {% if g.debug and not g.debug_supress_header %}
                 <div class="debug">Controller : {{ c.controller }}<br/>Action : {{ c.action }}</div>
@@ -79,7 +78,7 @@
                 <span class="icon-bar"></span>
             </button>
             {# The .header-image class hides the main text and uses image replacement for the title #}
-            <hgroup class="{{ g.header_class }} pull-left">
+            <div class="{{ g.header_class }} pull-left">
 
                 {% block header_logo %}
                     {% if g.site_logo %}
@@ -92,7 +91,7 @@
                     {% endif %}
                 {% endblock %}
 
-            </hgroup>
+            </div>
 
             {% block header_site_search %}
                 <div class="site-search-wrap">
@@ -117,7 +116,7 @@
                 </div>
             {% endblock %}
 
-            <div class="nav-collapse collapse">
+            <div class="nav-collapse collapse" role="navigation" aria-label="Main menu">
 
                 {% block header_site_navigation %}
                     <nav class="section navigation">
@@ -136,5 +135,6 @@
 
             </div>
         </div>
-    </header>
+    </div>
+</header>
 {% endblock %}


### PR DESCRIPTION
Hi @ebuckley 

These changes include the following

- All elements in the header sit in one 'header' element
- Header element has role=banner
- Inside the header are two 'nav' elements each with ARIA role=navigation
- The nav element that contains "Request Dataset" "Add dataset" has the aria-label="Add/Request Dataset"
- The nav element that contains main site navigation has the aria-label="Main Menu"
-  Using a 'div' instead of 'hgroup' element because the 'hgroup' element has been removed from HTML5 specification
- There are no changes visually to the header (desktop view or mobile views)
- Changes have been replicated from CWP (https://github.com/GOVTNZ/datagovtnz/pull/41)