### PR TITLE
Header search form accessibility fixes

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -8515,6 +8515,11 @@ div.not-authored {
   color: #fff;
   text-shadow: none;
 }
+.masthead.navbar .sr-only {
+  position: absolute !important;
+  top: -9999px !important;
+  left: -9999px !important;
+}
 .masthead.navbar .site-search-wrap {
   padding: 5px;
   background-color: #004a61;
@@ -8713,6 +8718,11 @@ div.not-authored {
 .site-footer .nav > .active > a:focus {
   color: #fff;
   text-shadow: none;
+}
+.site-footer.navbar .sr-only {
+  position: absolute !important;
+  top: -9999px !important;
+  left: -9999px !important;
 }
 .site-footer.navbar .site-search-wrap {
   padding: 5px;

--- a/ckanext/dia_theme/less/masthead.less
+++ b/ckanext/dia_theme/less/masthead.less
@@ -181,6 +181,11 @@ div {
   }
 
   &.navbar {
+    .sr-only {
+      position: absolute !important;
+      top: -9999px !important;
+      left: -9999px !important;
+    }
     .site-search-wrap {
       padding: 5px;
       background-color: #004a61;

--- a/ckanext/dia_theme/templates/header_base.html
+++ b/ckanext/dia_theme/templates/header_base.html
@@ -93,21 +93,25 @@
                     <form class="section site-search simple-input" action="{% url_for controller='package', action='search' %}" method="get">
                         <div class="field">
                             <input class="ss-search-url" value="{{ h.parent_site_url() }}/search/SearchForm" type="hidden">
-                            <input id="field-sitewide-search" type="text" name="q" placeholder="{{ _('Search') }}" class="search" />
+                            <input id="field-sitewide-search" type="text" name="q" placeholder="{{ _('E.g. environment') }}" class="search" aria-label="Search term"/>
                             <label for="field-sitewide-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
-                            <button class="btn-search" type="submit" role="presentation" tabindex="-1"><i class="fa fa-search icon-search"></i></button>
+                            <button class="btn-search" type="submit">
+                                <i class="fa fa-search icon-search"></i>
+                                <span class="sr-only">Search</span>
+                            </button>
                         </div>
                     </form>
-                    <div class="context-switch">
-                        <label for="search-for-website-content">
-                            <input type="radio" class="search-form-context" name="header-search-context" value="content" id="search-for-website-content">
-                            Website
-                        </label>
-                        <label for="search-for-datasets">
-                            <input type="radio" class="search-form-context" name="header-search-context" value="datasets" checked="checked" id="search-for-datasets">
-                            Datasets
-                        </label>
-                    </div>
+                    <fieldset class="fieldset">
+                        <legend class="hide">Search for</legend>
+                        <div class="context-switch">
+                            <input type="radio" class="search-form-context" name="header-search-context" value="datasets" id="search-for-datasets">
+                            <label for="search-for-datasets">Datasets</label>
+                        </div>
+                        <div class="context-switch">
+                            <input type="radio" class="search-form-context" name="header-search-context" value="content" checked="checked" id="search-for-website-content">
+                            <label for="search-for-website-content">Website</label>
+                        </div>
+                    </fieldset>
                 </div>
             {% endblock %}
 
@@ -115,6 +119,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
+                <span class="sr-only">Main navigation</span>
             </button>
 
             <div id="collapseDiv" class="nav-collapse collapse" role="navigation" aria-label="Main menu">


### PR DESCRIPTION
These are changes that have also been implmented in the CWP site (the search form in the header)

Acceptance Criteria

- [x] The text “search" is replaced with an example of a search term i.e. environment

- [x] Radio elements belong to a fieldset element and have a legend as a label

- [x] Remove role=”presentation” and tabindex="-1" from the search button

- [x]  The Search text in the search component should be readable by screen readers.

- [x] The visual display of the search component is unchanged

Have tested with chrome vox, will test with NVDA once on UAT / go live

:pear: 