### PR TITLE
Changed html-lang attribute to en-AU

### DIFF
--- a/ckanext/dia_theme/templates/page.html
+++ b/ckanext/dia_theme/templates/page.html
@@ -1,5 +1,13 @@
 {% extends "base.html" %}
 
+{%- block htmltag -%}
+{% set lang = "en-AU" %}
+<!--[if IE 7]> <html lang="{{ lang }}" class="ie ie7"> <![endif]-->
+<!--[if IE 8]> <html lang="{{ lang }}" class="ie ie8"> <![endif]-->
+<!--[if IE 9]> <html lang="{{ lang }}" class="ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="{{ lang }}"> <!--<![endif]-->
+{%- endblock -%}
+
 {%- block page -%}
 
   {% block skip %}


### PR DESCRIPTION
**Acceptance criteria**
- [ ] The language is correctly set English (Australian)

**Background**
The language attribute is generated by the template `src/ckan-core/ckan/templates/base.html` by a call to `lang()` defined in `src/ckan-core/ckan/lib/helpers.py`. That function uses  a request var called `CKAN_LANG` which in turn is set by `src/ckan-core/ckan/config/middleware/common_middleware.py` by one of two methods;

1. if the user supplied a specific language attribute in the URL, then that is used to populate the var, \- or \-

1. if that hasn't been used, then the system default config option `ckan.locale_default` is used. 

The system default can't be changed to `en-AU` because during startup, that variable is checked against CKAN valid i18n options. And `en-AU` isn’t a valid option, according to CKAN and as a result, CKAN won’t start.

In `src/ckan-core/ckan/templates/base.html` the `html` attribute is rendered in a block which I've overridden in `src/ckanext-dia_theme/ckanext/dia_theme/templates/page.html` to set a hard-coded value for the `lang` attribute.