### PR TITLE
Added aria-hidden to font-icons

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.js
+++ b/ckanext/dia_theme/fanstatic/dia_custom.js
@@ -31,5 +31,9 @@
             }
         });
 
+        // .icon-globe and .icon-filter is part of the core ckan codebase
+        // instead of copying over a lot of core templates, just applied the aria-hidden here
+        $( 'i.icon-globe, i.icon-filter' ).attr('aria-hidden', 'true');
+
     });
 }(jQuery));

--- a/ckanext/dia_theme/templates/footer.html
+++ b/ckanext/dia_theme/templates/footer.html
@@ -50,7 +50,7 @@
 			</ul>
 	    </div>
 	    <div class="footlink footright">
-		<a href="#"><i class="fa icon-chevron-up"></i> &nbsp; Back to top</a>
+		<a href="#"><i class="fa icon-chevron-up" aria-hidden="true"></i> &nbsp; Back to top</a>
 	    </div>
 	</div>
 	<div class="row footsub">

--- a/ckanext/dia_theme/templates/header_base.html
+++ b/ckanext/dia_theme/templates/header_base.html
@@ -96,7 +96,7 @@
                             <input id="field-sitewide-search" type="text" name="q" placeholder="{{ _('E.g. environment') }}" class="search" aria-label="Search term"/>
                             <label for="field-sitewide-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
                             <button class="btn-search" type="submit">
-                                <i class="fa fa-search icon-search"></i>
+                                <i class="fa fa-search icon-search" aria-hidden="true"></i>
                                 <span class="sr-only">Search</span>
                             </button>
                         </div>

--- a/ckanext/dia_theme/templates/snippets/search_form.html
+++ b/ckanext/dia_theme/templates/snippets/search_form.html
@@ -13,7 +13,7 @@
       <input type="text" class="search" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
       <button type="submit" value="search">
-        <i class="fa fa-search icon-search"></i>
+        <i class="fa fa-search icon-search" aria-hidden="true"></i>
         <span>{{ _('Submit') }}</span>
       </button>
       {% endblock %}


### PR DESCRIPTION
**Acceptance criteria**
- [ ] All icons elements have the attribute aria-hidden=true

**Notes**
There are two icons that are rendered by ckan-core templates and not the custom dia-themes. We could raise a PR for those projects (@camfindlay should we?), but in the meantime I've applied the attribute in `dia_custom.js` for those icons.