### PR TITLE
FIX default search radio to datasets

### DIFF
--- a/ckanext/dia_theme/templates/header_base.html
+++ b/ckanext/dia_theme/templates/header_base.html
@@ -104,11 +104,11 @@
                     <fieldset class="fieldset">
                         <legend class="hide">Search for</legend>
                         <div class="context-switch">
-                            <input type="radio" class="search-form-context" name="header-search-context" value="datasets" id="search-for-datasets">
+                            <input type="radio" class="search-form-context" name="header-search-context" value="datasets" checked="checked" id="search-for-datasets">
                             <label for="search-for-datasets">Datasets</label>
                         </div>
                         <div class="context-switch">
-                            <input type="radio" class="search-form-context" name="header-search-context" value="content" checked="checked" id="search-for-website-content">
+                            <input type="radio" class="search-form-context" name="header-search-context" value="content" id="search-for-website-content">
                             <label for="search-for-website-content">Website</label>
                         </div>
                     </fieldset>


### PR DESCRIPTION
Default search context when in CKAN should be "Datasets" not "Website"