### PR TITLE
Print css styles

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -10644,10 +10644,6 @@ aside.secondary .module.module-narrow.license a {
   .module-content a[href^="/"]:after {
     content: " (https://data.govt.nz" attr(href) ") ";
   }
-  .module-content a#link-next:after,
-  .module-content a#link-prev:after {
-    display: none;
-  }
   .module-content a:after {
     font-size: 90%;
   }

--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -10605,6 +10605,82 @@ aside.secondary .module.module-narrow.social .nav-simple > li > a:hover {
 aside.secondary .module.module-narrow.license a {
   font-size: 13px;
 }
+@media print {
+  header,
+  nav,
+  footer,
+  aside,
+  .search-result-heading,
+  .tags {
+    display: none !important;
+  }
+  body {
+    margin-top: 40px;
+  }
+  body:before {
+    content: 'data.govt.nz';
+    font-weight: bold;
+    font-size: 2.5em;
+    margin-top: 20px;
+  }
+  .wrapper {
+    padding-top: 0 !important;
+  }
+  .wrapper .primary {
+    width: auto !important;
+  }
+  .module-content {
+    width: auto;
+    border: 0;
+    float: none !important;
+  }
+  .module-content a {
+    word-wrap: break-word;
+  }
+  .module-content a[href^="https://"]:after,
+  .module-content a[href^="http://"]:after {
+    content: " (" attr(href) ")";
+  }
+  .module-content a[href^="/"]:after {
+    content: " (https://data.govt.nz" attr(href) ") ";
+  }
+  .module-content a#link-next:after,
+  .module-content a#link-prev:after {
+    display: none;
+  }
+  .module-content a:after {
+    font-size: 90%;
+  }
+  .toolbar .breadcrumb:before {
+    content: 'You are here:';
+    float: left;
+    padding-right: .5em;
+    padding-top: 12px;
+  }
+  .toolbar {
+    padding-top: 1em;
+    margin-top: 30px !important;
+  }
+  .toolbar .breadcrumb {
+    margin: 0;
+    padding: 0;
+    float: left;
+    list-style: outside none none;
+    position: relative;
+  }
+  .toolbar .breadcrumb li {
+    float: left;
+  }
+  .toolbar .breadcrumb li:not(:last-child):after {
+    content: ">";
+    padding: 0 .25em;
+  }
+  .toolbar .breadcrumb li a {
+    border-bottom: none;
+    display: inline-block;
+    text-decoration: none;
+  }
+}
 header a:focus,
 .account-masthead a:focus,
 .breadcrumb a:focus,

--- a/ckanext/dia_theme/less/ckan.less
+++ b/ckanext/dia_theme/less/ckan.less
@@ -24,6 +24,8 @@
 @import "datapusher.less";
 @import "diamixins.less";
 @import "dia_custom.less";
+@import "dia_custom_print.less";
+
 @import "focus.less";
 
 body {

--- a/ckanext/dia_theme/less/dia_custom_print.less
+++ b/ckanext/dia_theme/less/dia_custom_print.less
@@ -1,0 +1,99 @@
+@media print {
+
+  header,
+  nav,
+  footer,
+  aside,
+  .search-result-heading,
+  .tags {
+    display: none !important;
+  }
+
+  body {
+    margin-top: 40px;
+  }
+
+  body:before {
+    content: 'data.govt.nz';
+    font-weight: bold;
+    font-size: 2.5em;
+    margin-top: 20px;
+  }
+
+  .wrapper {
+    padding-top: 0 !important;
+    .primary {
+      width: auto !important;
+    }
+  }
+
+  .module-content {
+    width: auto;
+    border: 0;
+    float: none !important;
+
+    a {
+      word-wrap: break-word; // make long links wrap and not break layout
+
+      // for external links
+      &[href^="https://"]:after,
+      &[href^="http://"]:after {
+        content: " (" attr(href) ")";
+      }
+
+      // and internal links
+      &[href^="/"]:after {
+        content: " (https://data.govt.nz" attr(href) ") ";
+      }
+
+      // but not prev/next links.
+      &#link-next,
+      &#link-prev{
+        &:after {
+          display: none;
+        }
+      }
+
+      &:after{
+        font-size: 90%;
+      }
+    }
+  }
+
+  // Add title 'You are here' to breadcrumbs
+  .toolbar {
+    .breadcrumb:before{
+      content: 'You are here:';
+      float: left;
+      padding-right: .5em;
+      padding-top: 12px;
+    }
+  }
+
+  // Keep breadcrumbs on one line
+  .toolbar{
+    padding-top: 1em;
+    margin-top: 30px !important;
+
+    .breadcrumb{
+      margin: 0;
+      padding: 0;
+      float:left;
+      list-style: outside none none;
+      position:relative;
+      li {
+        float:left;
+        &:not(:last-child):after {
+          content: ">";
+          padding: 0 .25em;
+        }
+        a {
+          border-bottom:none;
+          display:inline-block;
+          text-decoration:none;
+        }
+      }
+    }
+  }
+
+}

--- a/ckanext/dia_theme/less/dia_custom_print.less
+++ b/ckanext/dia_theme/less/dia_custom_print.less
@@ -46,14 +46,6 @@
         content: " (https://data.govt.nz" attr(href) ") ";
       }
 
-      // but not prev/next links.
-      &#link-next,
-      &#link-prev{
-        &:after {
-          display: none;
-        }
-      }
-
       &:after{
         font-size: 90%;
       }


### PR DESCRIPTION
Custom print.less file added to: 

- Style/hide common elements

- Show content link urls 

- Inject site title and breadcrumb titles to aid comprehension