### PR TITLE
Update/header footer links data 371

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -7257,7 +7257,7 @@ textarea {
 }
 .search-form .search-input {
   position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }
 .search-form .search-input input {
   -webkit-box-sizing: border-box;
@@ -7304,6 +7304,9 @@ textarea {
 .search-form .search-input.search-giant button i {
   font-size: 28px;
   width: 28px;
+}
+.search-form .control-order-by {
+  margin-top: 10px;
 }
 .search-form .control-order-by label,
 .search-form .control-order-by select {
@@ -7371,15 +7374,52 @@ textarea {
     margin: 0;
   }
 }
-a.search-context-switch {
-  margin-bottom: 20px;
+.search-alt-actions {
   display: inline-block;
-  border-bottom: 2px solid #dddddd;
-  color: #333;
+  margin-left: 10px;
 }
-a.search-context-switch:hover {
-  text-decoration: none;
-  border-bottom: 2px solid #075D79;
+a.search-context-switch,
+a.dataset-request {
+  font-weight: normal;
+  margin-left: 5px;
+  padding: 10px 20px;
+  border: none;
+  margin-bottom: 5px;
+  margin-top: 5px;
+  -webkit-font-smoothing: antialiased;
+}
+a.search-context-switch:hover,
+a.dataset-request:hover,
+a.search-context-switch:focus,
+a.dataset-request:focus {
+  text-decoration: underline;
+}
+a.search-context-switch {
+  color: #fff;
+  border-bottom: 2px solid #0a3e4e;
+}
+a.dataset-request {
+  border-bottom: 2px solid #ab7701;
+}
+a.dataset-request:hover,
+a.dataset-request:focus {
+  background-color: #e8a200;
+}
+.search-result-api-message {
+  display: inline-block;
+  padding: 10px 20px;
+  border-radius: 3px;
+  background-color: #ceecf6;
+  border-bottom: 2px solid #b2cbd4;
+  margin-left: 5px;
+}
+.search-result-api-message span {
+  font-size: 1.3em;
+  vertical-align: middle;
+  margin-right: 10px;
+}
+.request-data {
+  margin-top: 40px;
 }
 .group .media-vertical .image {
   margin: 0 -5px 5px;
@@ -7464,7 +7504,7 @@ a.search-context-switch:hover {
   display: none;
 }
 .toolbar .breadcrumb a {
-  color: #505050;
+  color: #333;
 }
 @media (max-width: 767px) {
   .toolbar .breadcrumb {
@@ -8366,7 +8406,7 @@ div.masthead {
   background-image: none;
   color: #fff;
   min-height: 55px;
-  margin-top: 20px;
+  margin-top: 45px;
 }
 div.masthead a {
   border-bottom: none;
@@ -8828,7 +8868,7 @@ div.not-authored {
   height: 20px;
 }
 .site-footer .nav > li > a:hover {
-  background-color: #529db6;
+  background-color: #FFB100;
 }
 .site-footer .simple-input {
   height: 30px;
@@ -9643,7 +9683,7 @@ header.account-masthead .account ul li a {
   padding: 5px 15px;
 }
 header.account-masthead .account ul li a:hover {
-  background-color: #529db6;
+  background-color: #FFB100;
 }
 .masthead {
   background-image: none;
@@ -9654,7 +9694,7 @@ header.account-masthead .account ul li a:hover {
   height: 20px;
 }
 .masthead .nav > li > a:hover {
-  background-color: #529db6;
+  background-color: #FFB100;
 }
 .masthead .simple-input {
   height: 30px;
@@ -10252,15 +10292,32 @@ header.account-masthead .account ul li a:hover {
 .simple-input .field .btn-search .icon-search {
   font-size: 20px;
 }
+.btn-secondary {
+  color: #333;
+  background-color: #ffc645;
+  background-image: -moz-linear-gradient(top, #ffc645, #e8a200);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffc645), to(#e8a200));
+  background-image: linear-gradient(to bottom, #ffc645, #e8a200);
+  text-shadow: none;
+}
+.btn-secondary:hover,
+.btn-secondary:focus,
+.btn-secondary:active,
+.btn-secondary.active,
+.btn-secondary.disabled,
+.btn-secondary[disabled] {
+  background-color: #ffb100;
+  color: #333;
+}
 .toolbar {
-  background-color: #0c536b;
-  color: #FFFFFF;
+  background-color: #FFB100;
+  color: #333;
   /* add back negative margin value */
   padding: 0.25rem 9999rem;
   margin: -10px -9999rem 0;
 }
 .toolbar .breadcrumb > li > a {
-  color: #FFFFFF;
+  color: #333;
   font-size: 14px;
   text-shadow: none;
 }
@@ -10765,7 +10822,7 @@ header textarea:focus,
 .breadcrumb textarea:focus,
 .site-footer textarea:focus {
   outline: none !important;
-  box-shadow: 0 0 0 2px #f5f3f3 !important;
+  box-shadow: 0 0 0 2px #FFFFFF !important;
   text-decoration: none !important;
 }
 #field-sitewide-search:focus {

--- a/ckanext/dia_theme/less/dia_custom.less
+++ b/ckanext/dia_theme/less/dia_custom.less
@@ -18,8 +18,8 @@
 @layoutTrimBackgroundColor: #FFFFFF;
 @layoutTrimBorderColor: #CCCCCC;
 @layoutTagBackgroundColor: #BADAE2;
-@layoutToolbarColor: #FFFFFF;
-@layoutToolbarBackgroundColor: #529db6;
+@layoutToolbarColor: #333;
+@layoutToolbarBackgroundColor: #FFB100;
 @layoutNumsBackgroundColor: #EDF9FD;
 
 @mastheadTextColor: #FFFFFF;
@@ -40,6 +40,7 @@
 @footerTextColor: #FFFFFF;
 @footerBackgroundColor: #0c536b;
 @footerLinkColor: @footerTextColor;
+@focusOnBlueBg: @footerTextColor;
 
 //Tab Navigation
 @tabBackgroundColor: #117799;
@@ -354,6 +355,7 @@ header.account-masthead {
       background-color: @layoutToolbarBackgroundColor;
     }
   }
+
 
   .simple-input {
     height: 30px;
@@ -670,8 +672,22 @@ header.account-masthead {
   font-size: 20px;
 }
 
+.btn-secondary {
+  color: #333;
+  background-color: #ffc645;
+  background-image: -moz-linear-gradient(top, #ffc645, #e8a200);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffc645), to(#e8a200));
+  background-image: linear-gradient(to bottom, #ffc645, #e8a200);
+  text-shadow: none;
+
+  &:hover, &:focus, &:active, &.active, &.disabled, &[disabled] {
+    background-color: #ffb100;
+    color: #333;
+  }
+}
+
 .toolbar {
-  background-color: @footerBackgroundColor;
+  background-color: @layoutToolbarBackgroundColor;
   color: @layoutToolbarColor;
 
   /* add back negative margin value */
@@ -1134,7 +1150,3 @@ aside.secondary {
   }
 
 }
-
-
-
-

--- a/ckanext/dia_theme/less/masthead.less
+++ b/ckanext/dia_theme/less/masthead.less
@@ -6,7 +6,7 @@ div {
     background-image: none;
     color:#fff;
     min-height: 55px;
-    margin-top: 20px;
+    margin-top: 45px;
     a {
       border-bottom:none;
       color: #ffffff;

--- a/ckanext/dia_theme/less/search.less
+++ b/ckanext/dia_theme/less/search.less
@@ -7,7 +7,7 @@
   // Normal search box
   .search-input {
     position: relative;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
   	input {
       .box-sizing(border-box);
       margin: 0;
@@ -53,6 +53,8 @@
     }
   }
   .control-order-by {
+    margin-top: 10px;
+
     label,
     select {
       display: inline;
@@ -126,14 +128,55 @@
     }
   }
 }
-a.search-context-switch {
-  margin-bottom: 20px;
-  display: inline-block;
-  border-bottom: 2px solid #dddddd;
-  color: #333;
 
-  &:hover {
-    text-decoration: none;
-    border-bottom: 2px solid #075D79;
+.search-alt-actions {
+  display: inline-block;
+  margin-left: 10px;
+}
+
+a.search-context-switch,
+a.dataset-request {
+  font-weight: normal;
+  margin-left: 5px;
+  padding: 10px 20px;
+  border: none;
+  margin-bottom: 5px;
+  margin-top: 5px;
+  -webkit-font-smoothing: antialiased;
+
+  &:hover, &:focus {
+    text-decoration: underline;
   }
+}
+
+a.search-context-switch {
+  color: #fff;
+  border-bottom: 2px solid #0a3e4e;
+}
+
+a.dataset-request {
+  border-bottom: 2px solid #ab7701;
+
+  &:hover, &:focus {
+    background-color: #e8a200;
+  }
+}
+
+.search-result-api-message {
+  display: inline-block;
+  padding: 10px 20px;
+  border-radius: 3px;
+  background-color: #ceecf6;
+  border-bottom: 2px solid #b2cbd4;
+  margin-left: 5px;
+
+  span {
+    font-size: 1.3em;
+    vertical-align: middle;
+    margin-right: 10px;
+  }
+}
+
+.request-data {
+  margin-top: 40px;
 }

--- a/ckanext/dia_theme/less/variables.less
+++ b/ckanext/dia_theme/less/variables.less
@@ -34,7 +34,7 @@
 @emptyTextColor: #aaa;
 @genericBorderColor: #ddd;
 
-@breadcrumbTextColor: #505050;
+@breadcrumbTextColor: #333;
 
 @mastheadTextColor: #fff;
 @mastheadLinkColor: @mastheadTextColor;

--- a/ckanext/dia_theme/templates/footer.html
+++ b/ckanext/dia_theme/templates/footer.html
@@ -2,15 +2,13 @@
     <div class="container">
         <div class="row">
 	    <div class="span3">
-		<h2 class="footcolheader">About us</h2>
+		<h2 class="footcolheader">Get in touch</h2>
 			<ul>
 				<li class="footlink"><a href="{{ h.parent_site_url() }}/contact-us/" class="link">Contact us</a></li>
 
-				<li class="footlink"><a href="{{ h.parent_site_url() }}/about-this-site/" class="link">About data.govt.nz</a></li>
-
 				<li class="footlink"><a href="{{ h.parent_site_url() }}/feedback/" class="link">Give us feedback</a></li>
-
-				<li class="footlink"><a href="{{ h.url_for(controller="ckanext.stats.controller:StatsController", action="index") }}#total-datasets" class="link">Statistics</a></li>
+				<li class="footlink"><a href="https://github.com/data-govt-nz" class="link">Github</a></li>
+				<li class="footlink"><a href="{{ h.parent_site_url() }}/request-data/" class="link">Request a dataset</a></li>
 			</ul>
 	    </div>
 	    <div class="span6">
@@ -18,20 +16,20 @@
 		<div class="footcol02A">
 			<ul>
 				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}" class="link">Home</a></li>
-				
-				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/community/" class="link">Community</a></li>
-				
-				<li class="footlink footlink50"><a href="{{ h.url_for(controller="package", action="search") }}" class="link">Datasets</a></li>
-				
+
+				<li class="footlink footlink50"><a href="{{ h.url_for(controller="package", action="search") }}" class="link">Get datasets</a></li>
+
+				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/manage-data/" class="link">Manage data</a></li>
+
+				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/use-data/" class="link">Use data</a></li>
+
+				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/open-data/" class="link">Open data</a></li>
+
+				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/events/" class="link">Events</a></li>
+
 				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/blog/" class="link">Blog</a></li>
-				
-				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/standards-and-guidance/" class="link">Standards &amp; guidance</a></li>
-				
-				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/request-data/" class="link">Request dataset</a></li>
-				
-				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/case-studies/" class="link">Case studies</a></li>
-				
-				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/add-dataset/" class="link">Add dataset</a></li>
+
+				<li class="footlink footlink50"><a href="{{ h.parent_site_url() }}/about/" class="link">About</a></li>
 			</ul>
 		</div>
 	    </div>
@@ -43,8 +41,6 @@
 				<li class="footlink"><a href="{{ h.parent_site_url() }}/privacy-policy/" class="link">Privacy policy</a></li>
 
 				<li class="footlink"><a href="{{ h.parent_site_url() }}/copyright/" class="link">Copyright</a></li>
-
-				<li class="footlink"><a href="{{ h.parent_site_url() }}/developers/" class="link">Developers</a></li>
 
 				<li class="footlink"><a href="{{ h.url_for(controller="user", action="login") }}" class="link">Publisher login</a></li>
 			</ul>

--- a/ckanext/dia_theme/templates/header.html
+++ b/ckanext/dia_theme/templates/header.html
@@ -1,20 +1,20 @@
 {% extends "header_base.html" %}
-  {% block header_account_logged %}
-      {% snippet "snippets/topbar_links_loggedin.html" %}
-      {{ super() }}
-  {% endblock %}
 
-  {% block header_account_notlogged %}
-      {% snippet "snippets/topbar_links.html" %}
-  {% endblock %}
+{% block header_account_logged %}
+    {{ super() }}
+{% endblock %}
 
-  {% block header_site_navigation_tabs %}
-      <li><a href="{{ h.parent_site_url() }}">Home</a></li>
-      {{ h.build_nav_main(
-          ('search', _('Datasets')),
-      ) }}
-      <li><a href="{{ h.parent_site_url() }}/standards-and-guidance">Standards &amp; guidance</a></li>
-      <li><a href="{{ h.parent_site_url() }}/case-studies">Case studies</a></li>
-      <li><a href="{{ h.parent_site_url() }}/community">Community</a></li>
-      <li><a href="{{ h.parent_site_url() }}/blog">Blog</a></li>
+{% block header_account_notlogged %}
+{% endblock %}
+
+{% block header_site_navigation_tabs %}
+    {{ h.build_nav_main(
+        ('search', _('Get datasets')),
+    ) }}
+    <li><a href="{{ h.parent_site_url() }}/manage-data/">Manage data</a></li>
+    <li><a href="{{ h.parent_site_url() }}/use-data/">Use data</a></li>
+    <li><a href="{{ h.parent_site_url() }}/open-data/">Open data</a></li>
+    <li><a href="{{ h.parent_site_url() }}/events/">Events</a></li>
+    <li><a href="{{ h.parent_site_url() }}/blog/">Blog</a></li>
+    <li><a href="{{ h.parent_site_url() }}/about/">About</a></li>
 {% endblock %}

--- a/ckanext/dia_theme/templates/package/search.html
+++ b/ckanext/dia_theme/templates/package/search.html
@@ -76,6 +76,16 @@
 {% endblock %}
 
 
+{# Add a link to add datasets below search results #}
+{% block package_search_results_api_inner %}
+  <a href="{{ h.parent_site_url() }}/request-data/" title="Search for requested datasets or create a new request" class="btn btn-secondary dataset-request">Request a dataset</a>
+  <div class="search-result-api-message">
+    <span class="fa fa-lightbulb-o"></span>
+    {{ super() }}
+  </div>
+{% endblock %}
+
+
 {% block secondary_content %}
 
 <a href="#filters" class="visuallyhidden focusable skip-to-content">Skip map</a>

--- a/ckanext/dia_theme/templates/snippets/search_form.html
+++ b/ckanext/dia_theme/templates/snippets/search_form.html
@@ -46,6 +46,10 @@
 
   {% if query %}
     {% set link_href = _('{site}/search/SearchForm?Search={query}') %}
-    <a href="{{ link_href.format(site=h.parent_site_url(), query=query) }}" title="Search for website content instead" id="search-context-switch" class="search-context-switch">Were you looking for website content?</a>
+    Can't find it?
+    <div class="search-alt-actions">
+      <a href="{{ link_href.format(site=h.parent_site_url(), query=query) }}" title="Search for data.govt.nz website content instead" id="search-context-switch" class="btn btn-primary search-context-switch">Search for website content</a>
+      <a href="{{ h.parent_site_url() }}/request-data/" title="Search for requested datasets or create a new request" class="btn btn-secondary dataset-request">Request a dataset</a>
+    </div>
   {%- endif -%}
 </form>

--- a/ckanext/dia_theme/templates/snippets/topbar_links.html
+++ b/ckanext/dia_theme/templates/snippets/topbar_links.html
@@ -1,2 +1,0 @@
-<li class="feedback"><a href="{{ h.parent_site_url() }}/request-data">Request dataset</a></li>
-<li><a href="{{ h.parent_site_url() }}/add-dataset">Add dataset</a></li>

--- a/ckanext/dia_theme/templates/snippets/topbar_links_loggedin.html
+++ b/ckanext/dia_theme/templates/snippets/topbar_links_loggedin.html
@@ -1,2 +1,0 @@
-<li class="feedback"><a href="{{ h.parent_site_url() }}/request-data">Request dataset</a></li>
-<li><a href="{{ h.url_for(controller='package', action='new') }}">Add dataset</a></li>


### PR DESCRIPTION
Removes tabs from top and adds a "Request a dataset" link to the bottom of search results for now (see img below) as an idea of how we could surface it (shows whether or not a result is found).

Updated header/footer links to match new proposed IA.


![image](https://user-images.githubusercontent.com/1852796/44064386-dce53e44-9fb8-11e8-86e1-24703aacd19a.png)
