### PR TITLE
disable alternative links on the search view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.4.1
+ - Hide the rel=alternative link tags that are added to the head from the ckanext-dcat plugin
+
 ## 1.4.0
  - Include only RDF for content negotiation
 

--- a/ckanext/dia_theme/templates/package/search.html
+++ b/ckanext/dia_theme/templates/package/search.html
@@ -1,6 +1,11 @@
 {% ckan_extends %}
 
 
+{% block links %}
+    <!-- see DATA-390 Copied from the global theme, because we do not want to include the override of the links block done by the ckanext-dcat plugin-->
+    <link rel="shortcut icon" href="{{ g.favicon }}" />
+{% endblock %}
+
 {# Show the search form at the very top instead (with a heading added) #}
 {% block pre_primary %}
   <section class="search-result-heading">

--- a/ckanext/dia_theme/templates/package/search.html
+++ b/ckanext/dia_theme/templates/package/search.html
@@ -2,7 +2,8 @@
 
 
 {% block links %}
-    <!-- see DATA-390 Copied from the global theme, because we do not want to include the override of the links block done by the ckanext-dcat plugin-->
+
+{# see DATA-390 Copied from the global theme, because we do not want to include the override of the links block done by the ckanext-dcat plugin #}
     <link rel="shortcut icon" href="{{ g.favicon }}" />
 {% endblock %}
 


### PR DESCRIPTION
The only other override of the `links` block is the ckanext-dcat plugin, so we can safely override it and include the `rel=shortcut icon` link manually.