### PR TITLE
DATA-129: fix multipolygons that span the 180th meridian

### DIFF
--- a/ckanext/dia_theme/helpers.py
+++ b/ckanext/dia_theme/helpers.py
@@ -1,5 +1,6 @@
 from ckan.common import config
 import ckan.plugins.toolkit as toolkit
+import json
 
 
 def parent_site_url():
@@ -10,3 +11,39 @@ def parent_site_url():
     setting is missing
     """
     return config.get('ckan.parent_site_url', toolkit.h.url('home'))
+
+
+def modify_geojson(geojson_string):
+    """
+    Returns 'fixed' geojson if the input is a Polygon or MultiPolygon type.
+    Valid geojson should be within the -180, 180 range, but for most datasets this will render a very zoomed out view of
+    the map. Instead, we map latitudes under 0th meridian to be +360, which makes the map look a lot nicer for most
+    polygons that span the 180th meridian.
+
+    :param geojson_string:
+    :return:
+    """
+    obj = json.loads(geojson_string)
+
+    if isinstance(obj, dict):
+        new_coords = []
+        if obj.get('type', None) == 'Polygon':
+            for shape in obj.get('coordinates'):
+                new_coords.append([_modify(c) for c in shape])
+        elif obj.get('type', None) == 'MultiPolygon':
+            for shape in obj.get('coordinates'):
+                new_coords.append([[_modify(c) for c in shape[0]]])
+        else:
+            return geojson_string
+
+        obj['coordinates'] = new_coords
+        return json.dumps(obj)
+    else:
+        return geojson_string
+
+
+def _modify(coord):
+    lat, long = coord
+    if lat < 0:
+        lat = lat + 360
+    return [lat, long]

--- a/ckanext/dia_theme/plugin.py
+++ b/ckanext/dia_theme/plugin.py
@@ -17,5 +17,6 @@ class Dia_ThemePlugin(plugins.SingletonPlugin):
 
     def get_helpers(self):
         return {
-            'parent_site_url': helpers.parent_site_url
+            'parent_site_url': helpers.parent_site_url,
+            'modify_geojson': helpers.modify_geojson,
         }

--- a/ckanext/dia_theme/templates/package/snippets/info.html
+++ b/ckanext/dia_theme/templates/package/snippets/info.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
     {% block nums %}
         {%if pkg.spatial %}
-            {% snippet "spatial/snippets/dataset_map_base.html", extent=pkg.spatial %}
+            {% snippet "spatial/snippets/dataset_map_base.html", extent=h.modify_geojson(pkg.spatial) %}
         {% endif %}
     {% endblock %}
     


### PR DESCRIPTION
When a polygon contains polygon point that is between `-180,0` latitude, add 360 to the latitude. This is not valid GEOJSON, however leaflet renders this in more sensible ways for polygons across the antimeridian line.