### PR TITLE
hide the embed button, and use in-page link for the format icon

### DIFF
--- a/ckanext/dia_theme/templates/package/snippets/resource_view.html
+++ b/ckanext/dia_theme/templates/package/snippets/resource_view.html
@@ -1,0 +1,53 @@
+{% import 'macros/form.html' as form %}
+
+{% block resource_view %}
+  <div id="view-{{ resource_view['id'] }}" class="resource-view" data-id="{{ resource_view['id'] }}" data-title="{{ resource_view['title'] }}" data-description="{{ resource_view['descripion'] }}">
+    <p class="desc">{{ h.render_markdown(resource_view['description']) }}</p>
+    <div class="m-top ckanext-datapreview">
+      {% if not to_preview and h.resource_view_is_filterable(resource_view) %}
+        {% snippet 'package/snippets/resource_view_filters.html', resource=resource %}
+      {% endif %}
+      {% if not h.resource_view_is_iframed(resource_view) %}
+        {{ h.rendered_resource_view(resource_view, resource, package) }}
+      {% else %}
+        <div class="data-viewer-error js-hide">
+          <p class="text-error">
+            <i class="fa fa-info-circle"></i>
+            {{ _('This resource view is not available at the moment.') }}
+            <a href="#" data-toggle="collapse" data-target="#data-view-error">
+              {{ _('Click here for more information.') }}
+            </a>
+          </p>
+          <p id="data-view-error" class="collapse"></p>
+          <p>
+            <a href="{{ resource.url }}" class="btn btn-large resource-url-analytics" target="_blank">
+              <i class="fa fa-lg fa-arrow-circle-o-down"></i>
+              {{ _('Download resource') }}
+            </a>
+          </p>
+        </div>
+        {% if not to_preview %}
+          {% set current_filters = request.str_GET.get('filters') %}
+          {% if current_filters %}
+            {% set src = h.url_for(qualified=true, controller='package',
+                               action='resource_view', id=package['name'],
+                               resource_id=resource['id'],
+                               view_id=resource_view['id'],
+                               filters=current_filters)  %}
+          {% else %}
+            {% set src = h.url_for(qualified=true, controller='package',
+                               action='resource_view', id=package['name'],
+                               resource_id=resource['id'],
+                               view_id=resource_view['id'])  %}
+          {% endif %}
+        {% else %}
+          {# When previewing we need to stick the whole resource_view as a param as there is no other way to pass to information on to the iframe #}
+          {% set src = h.url_for(qualified=true, controller='package', action='resource_view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
+        {% endif %}
+        <iframe src="{{ src }}" frameborder="0" width="100%" data-module="data-viewer">
+          <p>{{ _('Your browser does not support iframes.') }}</p>
+        </iframe>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/ckanext/dia_theme/templates/snippets/package_item.html
+++ b/ckanext/dia_theme/templates/snippets/package_item.html
@@ -4,3 +4,11 @@
   {{ super() }}
   <span class="dataset-subheading">{{package.organization.title}}</span>
 {% endblock %}
+
+{% block resources_inner %}
+  {% for resource in h.dict_list_reduce(package.resources, 'format') %}
+    <li>
+      <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}#dataset-resources" class="label" data-format="{{ resource.lower() }}">{{ resource }}</a>
+    </li>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Implements the changes for Data-413 && DATA-379

# Changes
1. Override the resource_view snippet, and hide the embed button (otherwise copied from sources)
2. Implement the `resources_inner` block on the `package_item` snippet. We now include the `#dataset-resources` fragment on the format label links