### PR TITLE
fix/spatial_search_not_working_DATA-589

### DIFF
--- a/ckanext/dia_theme/templates/header_base.html
+++ b/ckanext/dia_theme/templates/header_base.html
@@ -120,7 +120,7 @@
                 <div class="site-search__visibility hidden" id="site-search" data-rua-toggle="slide" style="display: none;" aria-expanded="false">
                     <div class="container">
                         <div class="site-search__inner">
-                            <form class="search-form" action="{% url_for controller='package', action='search' %}" method="get">
+                            <form class="search-form" id="dataset-search" action="{% url_for controller='package', action='search' %}" method="get" data-module="select-switch">
                                 <label for="{$LabelPrefix}-field-sitewide-search">
                                     {{ _('Search for') }}:
                                 </label>


### PR DESCRIPTION
Added back accidentally deleted id that, when absent, broke spatial search.