### PR TITLE
Fix expanded map filter content overlap DATA-594

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -2237,7 +2237,7 @@ button.close {
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
-  *margin-left: .3em;
+  *margin-left: 0.3em;
   -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
   -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
   box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
@@ -2598,7 +2598,7 @@ input[type="submit"].btn.btn-mini {
   font-size: 0;
   vertical-align: middle;
   white-space: nowrap;
-  *margin-left: .3em;
+  *margin-left: 0.3em;
 }
 .btn-group:first-child {
   *margin-left: 0;
@@ -6101,7 +6101,7 @@ a.tag:hover {
   color: #333;
   font-weight: bold;
   text-decoration: underline solid black;
-  padding: .4em;
+  padding: 0.4em;
   display: inline-block;
   margin-bottom: 3px !important;
   margin-top: 3px !important;
@@ -6152,7 +6152,7 @@ a.tag:hover {
 }
 .nav-facet .nav-item > a:hover:after,
 .nav-facet .nav-item.active > a:after {
-  *margin-right: .3em;
+  *margin-right: 0.3em;
   display: inline-block;
   vertical-align: text-bottom;
   position: relative;
@@ -6227,7 +6227,7 @@ a.tag:hover {
 }
 .nav-facet-tertiary .nav li.active > a:hover:after,
 .nav-facet-tertiary .nav li.active > a:after {
-  *margin-right: .3em;
+  *margin-right: 0.3em;
   display: inline-block;
   vertical-align: text-bottom;
   position: relative;
@@ -7786,7 +7786,7 @@ h4 small {
   white-space: nowrap;
 }
 .ckan-icon {
-  *margin-right: .3em;
+  *margin-right: 0.3em;
   display: inline-block;
   vertical-align: text-bottom;
   position: relative;
@@ -7975,7 +7975,7 @@ h4 small {
   background-position: 0px -53px;
 }
 .format-label {
-  *margin-right: .3em;
+  *margin-right: 0.3em;
   display: inline-block;
   vertical-align: text-bottom;
   position: relative;
@@ -9534,7 +9534,7 @@ footer.site-footer .site-footer__col-3 h2 {
   margin-bottom: 1em;
 }
 .resource-view-filters .resource-view-filter {
-  margin-bottom: 1.0em;
+  margin-bottom: 1em;
 }
 .resource-view-filters .resource-view-remove-filter {
   cursor: pointer;
@@ -10888,9 +10888,22 @@ body li {
 #dataset-search-form {
   display: block;
 }
+.dataset-map-expanded #dataset-map {
+  top: -636px;
+}
 @media (max-width: 991px) {
   .col-md-9.primary {
     float: unset;
+  }
+  .dataset-map-expanded #dataset-map {
+    width: 100%;
+    top: -405px;
+  }
+  .dataset-map-expanded .wrapper {
+    margin-top: 0;
+  }
+  .dataset-map-expanded .wrapper > .secondary {
+    margin-top: 420px;
   }
 }
 @media print {
@@ -10938,7 +10951,7 @@ body li {
   .toolbar .breadcrumb:before {
     content: 'You are here:';
     float: left;
-    padding-right: .5em;
+    padding-right: 0.5em;
     padding-top: 12px;
   }
   .toolbar {
@@ -10957,7 +10970,7 @@ body li {
   }
   .toolbar .breadcrumb li:not(:last-child):after {
     content: ">";
-    padding: 0 .25em;
+    padding: 0 0.25em;
   }
   .toolbar .breadcrumb li a {
     border-bottom: none;

--- a/ckanext/dia_theme/less/dia_custom.less
+++ b/ckanext/dia_theme/less/dia_custom.less
@@ -1236,8 +1236,21 @@ body li {
 #dataset-search-form {
   display: block;
 }
+.dataset-map-expanded #dataset-map {
+  top: -636px;
+}
 @media (max-width: 991px) {
   .col-md-9.primary {
     float: unset;
+  }
+  .dataset-map-expanded #dataset-map {
+    width: 100%;
+    top: -405px;
+  }
+  .dataset-map-expanded .wrapper {
+    margin-top: 0;
+  }
+  .dataset-map-expanded .wrapper>.secondary {
+    margin-top: 420px;
   }
 }


### PR DESCRIPTION
When we changed to use the new column layout the column became `position: relative` so the absolutely positioned map now needs to be relative to that column rather than something further up the tree that it used to be relative to.

Included some overrides so that it scales nicely on smaller screens - however it can only do this by being below the results, because the column containing it is pushed below results and we don't have a fixed height for the results to be able to offset it above them.