### PR TITLE
Update/filters on small screens DATA-578

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -8168,10 +8168,11 @@ h4 small {
   overflow: hidden;
 }
 .show-filters.btn,
+.show-filters.button,
 .hide-filters {
   display: none;
 }
-@media (max-width: 768px) {
+@media (max-width: 990px) {
   .wrapper {
     margin: 0 -20px;
     border-width: 0;
@@ -8190,7 +8191,7 @@ h4 small {
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 1;
+    z-index: 5;
     padding: 10px;
     background-color: #000000;
     background-color: rgba(0, 0, 0, 0.5);
@@ -8204,6 +8205,7 @@ h4 small {
     -moz-border-radius: 4px;
     border-radius: 4px;
     overflow: hidden;
+    margin: 15px;
   }
   .js [role=main] .secondary .filters > div .module-footer {
     display: none;
@@ -8211,13 +8213,18 @@ h4 small {
   .js body.filters-modal .secondary .filters .hide-filters {
     display: inline-block;
     position: absolute;
-    top: 14px;
-    right: 17px;
+    top: 36px;
+    right: 40px;
     opacity: 0.6;
   }
   .js body.filters-modal .secondary .filters .hide-filters i {
+    display: none;
     font-size: 18px;
   }
+  .js body.filters-modal .secondary .filters .hide-filters .text {
+    display: inline-block;
+  }
+  .js .show-filters.button,
   .js .show-filters.btn {
     display: inline-block;
   }
@@ -10891,11 +10898,14 @@ body li {
 .dataset-map-expanded #dataset-map {
   top: -636px;
 }
-@media (max-width: 991px) {
+@media (max-width: 990px) {
   .col-md-9.primary {
     float: unset;
   }
-  .dataset-map-expanded #dataset-map {
+  #dataset-map {
+    display: none;
+  }
+  .dataset-map-expanded {
     width: 100%;
     top: -405px;
   }

--- a/ckanext/dia_theme/less/dia_custom.less
+++ b/ckanext/dia_theme/less/dia_custom.less
@@ -1239,11 +1239,14 @@ body li {
 .dataset-map-expanded #dataset-map {
   top: -636px;
 }
-@media (max-width: 991px) {
+@media (max-width: 990px) {
   .col-md-9.primary {
     float: unset;
   }
-  .dataset-map-expanded #dataset-map {
+  #dataset-map {
+    display: none;
+  }
+  .dataset-map-expanded {
     width: 100%;
     top: -405px;
   }

--- a/ckanext/dia_theme/less/layout.less
+++ b/ckanext/dia_theme/less/layout.less
@@ -61,10 +61,11 @@
   overflow:hidden;
 }
 .show-filters.btn,
+.show-filters.button,
 .hide-filters {
   display:none;
 }
-@media (max-width: 768px) {
+@media (max-width: 990px) {
   .wrapper {
     margin: 0 -20px;
     border-width: 0;
@@ -79,7 +80,7 @@
     left:0;
     right:0;
     bottom:0;
-    z-index:1;
+    z-index:5;
     padding:10px;
     background-color:rgb(0,0,0);
     background-color:rgba(0,0,0,0.50);
@@ -93,6 +94,7 @@
     -moz-border-radius: 4px;
     border-radius: 4px;
     overflow:hidden;
+    margin: 15px;
   }
   .js [role=main] .secondary .filters > div .module-footer {
     display:none;
@@ -100,13 +102,18 @@
   .js body.filters-modal .secondary .filters .hide-filters {
     display:inline-block;
     position:absolute;
-    top:14px;
-    right:17px;
+    top: 36px;
+    right: 40px;
     opacity:0.6;
     i {
+      display: none;
       font-size:18px;
     }
+    .text {
+      display: inline-block;
+    }
   }
+  .js .show-filters.button,
   .js .show-filters.btn {
     display:inline-block;
   }

--- a/ckanext/dia_theme/templates/package/search.html
+++ b/ckanext/dia_theme/templates/package/search.html
@@ -52,29 +52,6 @@
     {% endif %}
   {% endblock %}
 
-  {% block search_facets %}
-    {% if facets %}
-      <p class="filter-list">
-        {% for field in facets.fields %}
-          {% set search_facets_items = facets.search.get(field)['items'] %}
-          <span class="facet">{{ facets.titles.get(field) }}:</span>
-          {% for value in facets.fields[field] %}
-            <span class="filtered pill">
-              {%- if facets.translated_fields and facets.translated_fields.has_key((field,value)) -%}
-                {{ facets.translated_fields[(field,value)] }}
-              {%- else -%}
-                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
-              {%- endif %}
-              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
-            </span>
-          {% endfor %}
-        {% endfor %}
-      </p>
-      <a class="show-filters btn">{{ _('Filter Results') }}</a>
-    {% endif %}
-  {% endblock %}
-
-
   {% if show_empty and count == 0 and not error %}
     {% trans %}
       <p class="extra">Please try another search.</p>

--- a/ckanext/dia_theme/templates/snippets/search_form.html
+++ b/ckanext/dia_theme/templates/snippets/search_form.html
@@ -37,9 +37,32 @@
             {% endfor %}
           </select>
           {% block search_sortby_button %}
-          <button class="btn js-hide" type="submit">{{ _('Go') }}</button>
+          <button class="button js-hide" type="submit">{{ _('Go') }}</button>
           {% endblock %}
         </div>
+      {% endif %}
+    {% endblock %}
+
+
+    {% block search_facets %}
+      {% if facets %}
+        <p class="filter-list">
+          {% for field in facets.fields %}
+            {% set search_facets_items = facets.search.get(field)['items'] %}
+            <span class="facet">{{ facets.titles.get(field) }}:</span>
+            {% for value in facets.fields[field] %}
+              <span class="filtered pill">
+                {%- if facets.translated_fields and facets.translated_fields.has_key((field,value)) -%}
+                  {{ facets.translated_fields[(field,value)] }}
+                {%- else -%}
+                  {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+                {%- endif %}
+                <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
+              </span>
+            {% endfor %}
+          {% endfor %}
+        </p>
+        <a class="show-filters button">{{ _('Filter Results') }}</a>
       {% endif %}
     {% endblock %}
 


### PR DESCRIPTION
It seems CKAN has some default behaviour that the filters on small screens disappear and show in a modal with a "Show filters" button, so I've just gotten that working properly:

 - Moved the search_facets block to where it's expected so that it renders the "show filters" button.
 - Updated the list to hide and modal to show at a larger break point so that there wasn't an in between state of having the filters column underneath results.
 - Tweaked style of modal to work with our new nav etc - not super pretty but usable at least.
 - Completely hiding the map filter if you're on a smaller screen. Alternatively we could just leave it at the bottom of the page (by removing the `display: none;`), because it scales down and looks/works alright, just isn't with the other filters in the modal.

Note this builds on https://github.com/data-govt-nz/ckanext-dia_theme/pull/37