### PR TITLE
Update override body padding for mobile screens DATA-582

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -10906,6 +10906,12 @@ body li {
     margin-top: 420px;
   }
 }
+@media (max-width: 767px) {
+  body {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
 @media print {
   header,
   nav,

--- a/ckanext/dia_theme/less/dia_custom.less
+++ b/ckanext/dia_theme/less/dia_custom.less
@@ -1254,3 +1254,9 @@ body li {
     margin-top: 420px;
   }
 }
+@media (max-width: 767px) {
+  body {
+      padding-left: 0;
+      padding-right: 0;
+  }
+}


### PR DESCRIPTION
This padding isn't needed with new designs.

However, I've noticed as of our previous changes (that are now live) we've lost the darker background of content areas like the data listing. If you compare production or this branch to the original screenshots on this ticket the darker background is gone. 