### PR TITLE
DATA-848 Increase the length at which search item descriptions are truncated.

### DIFF
--- a/ckanext/dia_theme/templates/snippets/package_item.html
+++ b/ckanext/dia_theme/templates/snippets/package_item.html
@@ -1,19 +1,83 @@
-{% ckan_extends %}
+{#
+  Displays a single of dataset.
 
-{% block heading %}
-  {{ super() }}
-  <span class="dataset-subheading">{{package.organization.title}}</span>
-{% endblock %}
+  package        - A package to display.
+  item_class     - The class name to use on the list item.
+  hide_resources - If true hides the resources (default: false).
+  banner         - If true displays a popular banner (default: false).
+  truncate       - The length to trucate the description to (default: 360)
+  truncate_title - The length to truncate the title to (default: 80).
 
-{% block resources_inner %}
-  {% for resource in h.dict_list_reduce(package.resources, 'format') %}
-    <li>
-      {% if h.check_ckan_version('2.9') %}
-        <a href="{{ h.url_for(package.type ~ '.read', id=package.name) }}#dataset-resources" class="label" data-format="{{ resource.lower() }}">{{ resource }}</a>
-      {% else %}
-        <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}#dataset-resources" class="label" data-format="{{ resource.lower() }}">{{ resource }}</a>
-      {% endif %}
+  Example:
+
+    {% snippet 'snippets/package_item.html', package=c.datasets[0] %}
+
+  #}
+  {% set truncate = truncate or 360 %}
+  {% set truncate_title = truncate_title or 80 %}
+  {% set title = package.title or package.name %}
+  {% set notes = h.markdown_extract(package.notes, extract_length=truncate) %}
+
+  {% block package_item %}
+    <li class="{{ item_class or "dataset-item" }}">
+      {% block content %}
+        <div class="dataset-content">
+          {% block heading %}
+            <h2 class="dataset-heading">
+            <span class="dataset-subheading">{{package.organization.title}}</span>
+              {% block heading_private %}
+                {% if package.private %}
+                  <span class="dataset-private label label-inverse">
+                      <i class="fa fa-lock"></i>
+                      {{ _('Private') }}
+                  </span>
+                {% endif %}
+              {% endblock %}
+              {% block heading_title %}
+          {{ h.link_to(h.truncate(title, truncate_title), h.url_for('%s.read' % package.type, id=package.name)) }}
+              {% endblock %}
+              {% block heading_meta %}
+                {% if package.get('state', '').startswith('draft') %}
+                  <span class="label label-info">{{ _('Draft') }}</span>
+                {% elif package.get('state', '').startswith('deleted') %}
+                  <span class="label label-danger">{{ _('Deleted') }}</span>
+                {% endif %}
+                {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
+              {% endblock %}
+            </h2>
+          {% endblock %}
+          {% block banner %}
+            {% if banner %}
+              <span class="banner">{{ _('Popular') }}</span>
+            {% endif %}
+          {% endblock %}
+          {% block notes %}
+            {% if notes %}
+              <div>{{ notes|urlize }}</div>
+            {% else %}
+              <p class="empty">{{ _("This dataset has no description") }}</p>
+            {% endif %}
+          {% endblock %}
+        </div>
+        {% block resources %}
+          {% if package.resources and not hide_resources %}
+            {% block resources_outer %}
+              <ul class="dataset-resources list-unstyled">
+                {% block resources_inner %}
+                  {% for resource in h.dict_list_reduce(package.resources, 'format') %}
+                  <li>
+                    {% if h.check_ckan_version('2.9') %}
+                      <a href="{{ h.url_for(package.type ~ '.read', id=package.name) }}#dataset-resources" class="label" data-format="{{ resource.lower() }}">{{ resource }}</a>
+                    {% else %}
+                      <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}#dataset-resources" class="label" data-format="{{ resource.lower() }}">{{ resource }}</a>
+                    {% endif %}
+                  </li>
+                  {% endfor %}
+                {% endblock %}
+              </ul>
+            {% endblock %}
+          {% endif %}
+        {% endblock %}
+      {% endblock %}
     </li>
-  {% endfor %}
-{% endblock %}
-
+  {% endblock %}


### PR DESCRIPTION
Pulls in the whole base template to adjust truncation of search result descriptions.