### PR TITLE
DATA-849 rationalise dates

### DIFF
--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -1948,11 +1948,24 @@ aside.secondary .module.module-narrow.license a {
   font-size: 13px;
 }
 .dataset-subheading {
+  margin-top: -8px;
+}
+.dataset-subheading,
+.dataset-modified-date {
   display: block;
   color: #666;
   font-size: 14px;
-  margin-top: -8px;
   margin-bottom: 8px;
+}
+.dataset-modified-date {
+  margin-top: 8px;
+  float: right;
+  text-align: right;
+}
+@media (max-width: 768px) {
+  .dataset-modified-date {
+    width: 100%;
+  }
 }
 /* override for rua styling */
 @media screen and (min-width: 1200px) {

--- a/ckanext/dia_theme/fanstatic/dia_custom.css
+++ b/ckanext/dia_theme/fanstatic/dia_custom.css
@@ -1947,24 +1947,40 @@ aside.secondary .module.module-narrow.social .nav-simple > li > a:hover {
 aside.secondary .module.module-narrow.license a {
   font-size: 13px;
 }
+.dataset-content .empty {
+  margin: 0;
+}
 .dataset-subheading {
   margin-top: -8px;
 }
 .dataset-subheading,
-.dataset-modified-date {
+.dataset-date {
   display: block;
   color: #666;
   font-size: 14px;
   margin-bottom: 8px;
 }
-.dataset-modified-date {
+.dataset-date {
   margin-top: 8px;
   float: right;
   text-align: right;
 }
+.dataset-date-created,
+.dataset-date-modified {
+  display: block;
+}
+.dataset-date-modified {
+  margin-left: 10px;
+}
+.dataset-item {
+  padding-bottom: 40px;
+}
 @media (max-width: 768px) {
-  .dataset-modified-date {
+  .dataset-date {
     width: 100%;
+  }
+  .dataset-item {
+    padding-bottom: 20px;
   }
 }
 /* override for rua styling */

--- a/ckanext/dia_theme/less/dia_custom.less
+++ b/ckanext/dia_theme/less/dia_custom.less
@@ -1153,27 +1153,46 @@ aside.secondary {
   }
 
 }
+
+.dataset-content .empty {
+  margin: 0;
+}
 .dataset-subheading {
   margin-top: -8px;
 }
 
 .dataset-subheading,
-.dataset-modified-date {
+.dataset-date {
   display: block;
   color: #666;
   font-size: 14px;
   margin-bottom: 8px;
 }
 
-.dataset-modified-date {
+.dataset-date {
   margin-top: 8px;
   float: right;
   text-align: right;
 }
 
+.dataset-date-created,
+.dataset-date-modified {
+  display: block;
+}
+.dataset-date-modified {
+  margin-left: 10px;
+}
+
+.dataset-item {
+  padding-bottom: 40px;
+}
+
 @media (max-width: 768px) {
-  .dataset-modified-date {
+  .dataset-date {
     width: 100%;
+  }
+  .dataset-item {
+    padding-bottom: 20px;
   }
 }
 

--- a/ckanext/dia_theme/less/dia_custom.less
+++ b/ckanext/dia_theme/less/dia_custom.less
@@ -1154,12 +1154,29 @@ aside.secondary {
 
 }
 .dataset-subheading {
+  margin-top: -8px;
+}
+
+.dataset-subheading,
+.dataset-modified-date {
   display: block;
   color: #666;
   font-size: 14px;
-  margin-top: -8px;
   margin-bottom: 8px;
 }
+
+.dataset-modified-date {
+  margin-top: 8px;
+  float: right;
+  text-align: right;
+}
+
+@media (max-width: 768px) {
+  .dataset-modified-date {
+    width: 100%;
+  }
+}
+
 /* override for rua styling */
 @media screen and (min-width: @media-widescreen) {
   body h2 {

--- a/ckanext/dia_theme/templates/snippets/metadata_created.html
+++ b/ckanext/dia_theme/templates/snippets/metadata_created.html
@@ -1,1 +1,1 @@
-<span class="footer">Record created {{  h.render_datetime(pkg.metadata_created) }}, Last Updated {{ h.render_datetime(pkg.metadata_modified)}}</span>
+<span class="footer">Dataset metadata created {{  h.render_datetime(pkg.metadata_created) }}, last updated {{ h.render_datetime(pkg.metadata_modified)}}</span>

--- a/ckanext/dia_theme/templates/snippets/package_item.html
+++ b/ckanext/dia_theme/templates/snippets/package_item.html
@@ -57,7 +57,10 @@
             {% else %}
               <p class="empty">{{ _("This dataset has no description") }}</p>
             {% endif %}
-            <span class='dataset-modified-date'>Updated {{ h.render_datetime(package.metadata_modified) }}</span>
+            <span class='dataset-date'>
+              <span class='dataset-date-created'>Created {{ h.render_datetime(package.metadata_created) }}</span>
+              <span class='dataset-date-updated'>Updated {{ h.render_datetime(package.metadata_modified) }}</span>
+            </span>
           {% endblock %}
         </div>
         {% block resources %}

--- a/ckanext/dia_theme/templates/snippets/package_item.html
+++ b/ckanext/dia_theme/templates/snippets/package_item.html
@@ -1,5 +1,5 @@
 {#
-  Displays a single of dataset.
+  Displays a single dataset.
 
   package        - A package to display.
   item_class     - The class name to use on the list item.
@@ -12,7 +12,7 @@
 
     {% snippet 'snippets/package_item.html', package=c.datasets[0] %}
 
-  #}
+#}
   {% set truncate = truncate or 360 %}
   {% set truncate_title = truncate_title or 80 %}
   {% set title = package.title or package.name %}
@@ -57,6 +57,7 @@
             {% else %}
               <p class="empty">{{ _("This dataset has no description") }}</p>
             {% endif %}
+            <span class='dataset-modified-date'>Updated {{ h.render_datetime(package.metadata_modified) }}</span>
           {% endblock %}
         </div>
         {% block resources %}

--- a/ckanext/dia_theme/templates/snippets/search_form.html
+++ b/ckanext/dia_theme/templates/snippets/search_form.html
@@ -31,6 +31,9 @@
           <label for="field-order-by">{{ _('Order by') }}</label>
           <select id="field-order-by" name="sort">
             {% for label, value in sorting %}
+              {% if form_id == 'dataset-search-form' and label == 'Last Modified' %}
+                {% set label = "Last Updated" %}
+              {% endif %}
               {% if label and value %}
                 <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
               {% endif %}

--- a/ckanext/dia_theme/templates/snippets/search_form.html
+++ b/ckanext/dia_theme/templates/snippets/search_form.html
@@ -31,7 +31,7 @@
           <label for="field-order-by">{{ _('Order by') }}</label>
           <select id="field-order-by" name="sort">
             {% for label, value in sorting %}
-              {% if form_id == 'dataset-search-form' and label == 'Last Modified' %}
+              {% if (form_id == 'dataset-search-form' or form_id == 'organization-datasets-search-form') and label == 'Last Modified' %}
                 {% set label = "Last Updated" %}
               {% endif %}
               {% if label and value %}


### PR DESCRIPTION
- Renames search order by dropdown from `Last Updated` to `Last Modified` .
- Adds created and modified dates to search results.
- See [companion PR](https://github.com/mediasuitenz/catalogue.data.govt.nz/pull/106) to rename in table dates. 