### PR TITLE
Use an actual lang value known to CKAN

### DIFF
--- a/ckanext/dia_theme/templates/page.html
+++ b/ckanext/dia_theme/templates/page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {%- block htmltag -%}
-{% set lang = "en-NZ" %}
+{% set lang = "en_AU" %}
 <!--[if IE 7]> <html lang="{{ lang }}" class="ie ie7"> <![endif]-->
 <!--[if IE 8]> <html lang="{{ lang }}" class="ie ie8"> <![endif]-->
 <!--[if IE 9]> <html lang="{{ lang }}" class="ie9"> <![endif]-->


### PR DESCRIPTION
Prior to 2.9.7 this was returning an empty translation set but it has started returning a 400 error.