### PR TITLE
Allow pagination to be displayed on small screen

### DIFF
--- a/ckanext/dia_theme/fanstatic/rua/css/rua.css
+++ b/ckanext/dia_theme/fanstatic/rua/css/rua.css
@@ -2876,12 +2876,9 @@ a.tag {
     border-radius: 100px;
     font-size: 16px;
     padding: 0;
-    display: none; }
+    display: inline-block; }
     .pagination li.current {
       display: inline-block; }
-    @media screen and (min-width: 952px) {
-      .pagination li {
-        display: inline-block; } }
   .pagination a,
   .pagination button {
     display: block;


### PR DESCRIPTION
Kia ora,

This just changes the CSS to not hide the pagination on small screens as there is no way to navigate to the other pages of a list if you are on a small screen, such as a phone. Images show how the before and after look on a "iPhone 11 Pro" (using Responsive Design Mode on Firefox)

Before:
![image](https://user-images.githubusercontent.com/1755886/236465172-1a8ea83c-2c38-4117-b3ed-90a9e4739743.png)

After:
![image](https://user-images.githubusercontent.com/1755886/236465452-3e842986-f81d-4aac-99ac-04b28b2b06fb.png)
