### PR TITLE
Prevent the browser validating hidden fields

### DIFF
--- a/ckanext/dia_theme/templates/package/snippets/resource_edit_form.html
+++ b/ckanext/dia_theme/templates/package/snippets/resource_edit_form.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block basic_fields %}
+    {{ super() }}
+
+    <script>
+        // Don't allow the browser to validate the form, should be done by server.
+        var formEl = document.getElementById('resource-edit')
+        formEl.setAttribute('novalidate', '')
+    </script>
+{% endblock %}
+


### PR DESCRIPTION
In some scenarios, the URL field has invalid info in it and is not visible to the end user. When they attempt to submit the form after uploading a new document, the form submission fails and the reason is invisible to the end user.