### PR TITLE
Override org dashboard tab template

### DIFF
--- a/ckanext/dia_theme/templates/user/dashboard_organizations.html
+++ b/ckanext/dia_theme/templates/user/dashboard_organizations.html
@@ -1,0 +1,25 @@
+{% extends "user/dashboard.html" %}
+
+{% block page_primary_action %}
+  {% if h.check_access('organization_create') %}
+    {% link_for h.humanize_entity_type('organization', org_type, 'add link') or _('Add Organization'), named_route=org_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
+  {% endif %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations') }}</h2>
+  {% set organizations = h.organizations_available(permission='manage_group',
+    include_dataset_count=True) %}
+  {% if organizations %}
+    <div class="wide">
+      {% snippet "organization/snippets/organization_list.html", organizations=organizations, show_capacity=True %}
+    </div>
+  {% else %}
+    <p class="empty">
+      {{ h.humanize_entity_type('organization', org_type, 'you not member') or _('You are not a member of any organizations.') }}
+      {% if h.check_access('organization_create') %}
+        {% link_for _('Create one now?'), named_route=org_type ~ '.new' %}
+      {% endif %}
+    </p>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
The builtin one in CKAN uses a group_type var that it attempts to override from the parent template, but it fails to do so. This causes the actions etc to describe/create Groups instead of Orgs.

Before:
![image](https://github.com/data-govt-nz/ckanext-dia_theme/assets/1121256/16b2d437-8804-4007-b989-f6b90dc7d671)

After:
![image](https://github.com/data-govt-nz/ckanext-dia_theme/assets/1121256/6f6f4cf8-ad0b-4426-ac56-171a9651bc44)
