### PR TITLE
Fix home route deprecation warning in logs

### DIFF
--- a/ckanext/dia_theme/helpers.py
+++ b/ckanext/dia_theme/helpers.py
@@ -10,7 +10,7 @@ def parent_site_url():
     ckan.parent_site_url, or value of h.url('home') if that
     setting is missing
     """
-    return config.get('ckan.parent_site_url', toolkit.h.url_for('home'))
+    return config.get('ckan.parent_site_url', toolkit.h.url_for('home.index'))
 
 
 def modify_geojson(geojson_string):


### PR DESCRIPTION
Route name "home" is deprecated and will be removed. Please update calls to use "home.index" instead

<img width="962" height="467" alt="image" src="https://github.com/user-attachments/assets/ea200e3e-374f-4f84-bd2c-df6896183627" />
